### PR TITLE
Issue 1346:	Patch for /nemerle/trunk/tools/nant-task/NantTask.n

### DIFF
--- a/tools/nant-task/NantTask.n
+++ b/tools/nant-task/NantTask.n
@@ -155,6 +155,9 @@ namespace Nemerle.Tools.NAntTasks
       when (DocFile != null) {
         WriteOption (writer, "doc", DocFile.FullName);
       }
+      when (Win32ResFile != null) {
+        WriteOption (writer, "win32-resource", Win32ResFile.FullName);
+      }
       when (Debug) {
         WriteOption (writer, "debug");
         WriteOption (writer, "def", "DEBUG");
@@ -203,6 +206,17 @@ namespace Nemerle.Tools.NAntTasks
     /// </remarks>
     [TaskAttribute ("doc")]
     public DocFile : FileInfo { get; set; }
+
+    /// <summary>
+    /// The name of a Win32 resource file to use.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Corresponds with the <c>-win32-resource:</c> flag.
+    /// </para>
+    /// </remarks>
+    [TaskAttribute ("win32res")]
+    public Win32ResFile : FileInfo { get; set; }
 
     /// <summary>
     /// Instructs the compiler not to import mscorlib.dll. The default is 


### PR DESCRIPTION
from googlecode. http://code.google.com/p/nemerle/issues/detail?id=1346

This adds support for the win32res attribute to the ncc nant task, bringing it a bit closer to the csc task.
