### PR TITLE
more generic generics support for code dom

### DIFF
--- a/ncc/codedom/NemerleCodeGenerator.n
+++ b/ncc/codedom/NemerleCodeGenerator.n
@@ -1412,7 +1412,7 @@ namespace Nemerle.Compiler
                 {
                   def typeArgs = array(r.TypeArguments.Count);
                   r.TypeArguments.CopyTo(typeArgs, 0);
-                  $<#$init[..$(typeArgs; ", "; expandGenerics)]#>
+                  $<#$init.[..$(typeArgs; ", "; expandGenerics)]#>
                 }
             }
             GetSafeTypeName(expandGenerics(ty));


### PR DESCRIPTION
This fixes some issues with asp.net currently

since we can write  List[Foo] and List.[Foo] for the type declaration
