### PR TITLE
Nemerle.WPF.DependencyProperty Warning: N10001 fix

### DIFF
--- a/snippets/Nemerle.WPF/Nemerle.WPF/DependencyProperty.n
+++ b/snippets/Nemerle.WPF/Nemerle.WPF/DependencyProperty.n
@@ -17,13 +17,13 @@ namespace Nemerle.WPF
   [MacroUsage(MacroPhase.BeforeInheritance, MacroTargets.Property, Inherited = false, AllowMultiple = false)]
   public macro DependencyProperty(typeBuilder : TypeBuilder, property : ParsedProperty, params options : list[PExpr])
   {
-    DependencyPropertyImpl.Implement(typeBuilder, property, options);
+    DependencyPropertyImpl.Implement(typeBuilder, property, Macros.ImplicitCTX(), options);
   }
 
   [MacroUsage(MacroPhase.BeforeInheritance, MacroTargets.Method, Inherited = false, AllowMultiple = false)]
   public macro DependencyProperty(typeBuilder : TypeBuilder, method : ParsedMethod, params options : list[PExpr])
   {
-    DependencyPropertyImpl.Implement(typeBuilder, method, options);
+    DependencyPropertyImpl.Implement(typeBuilder, method, Macros.ImplicitCTX(), options);
   }
 
   internal module DependencyPropertyImpl
@@ -135,10 +135,15 @@ namespace Nemerle.WPF
       readOnly
     }
 
-    private MakeGetValue(@this : PExpr, propertyName : string, propertyType : PExpr) : PExpr
+    private MakeGetValue(@this : PExpr, propertyName : string, propertyType : PExpr, typer : Typer) : PExpr
     {
       def name = PropertyFieldName(propertyName);
-      <[ $(@this).GetValue($(name : dyn)) :> $propertyType ]>
+      def propertyFixedType = typer.BindFixedType(propertyType);
+      
+      if(propertyFixedType.Equals(typer.InternalType.Object))
+        <[ $(@this).GetValue($(name : dyn))]>
+      else
+        <[ $(@this).GetValue($(name : dyn)) :> $propertyType ]>
     }
 
     private MakeSetValue(@this : PExpr, propertyName : string, readOnly : bool) : PExpr
@@ -164,7 +169,7 @@ namespace Nemerle.WPF
       ]>
     }
 
-    public Implement(typeBuilder : TypeBuilder, property : ClassMember.Property, options : list[PExpr]) : void
+    public Implement(typeBuilder : TypeBuilder, property : ClassMember.Property, typer : Typer, options : list[PExpr]) : void
     {
       def redundant = property.Attributes & ~NemerleAttributes.AccessModifiers;
       when(redundant != 0)
@@ -190,12 +195,12 @@ namespace Nemerle.WPF
       def propertyAccess = property.Attributes & NemerleAttributes.AccessModifiers;
 
       def readOnly = DeclareFields(typeBuilder, property.Name, propertyType, propertyAccess, options);
-      getter.Body = MakeGetValue(<[ this ]>, property.Name, propertyType);
+      getter.Body = MakeGetValue(<[ this ]>, property.Name, propertyType, typer); 
       setter.Attributes |= GetSetterAccessModifiers(readOnly, propertyAccess);
       setter.Body = MakeSetValue(<[ this ]>, property.Name, readOnly);
     }
 
-    public Implement(typeBuilder : TypeBuilder, method : ClassMember.Function, options : list[PExpr]) : void
+    public Implement(typeBuilder : TypeBuilder, method : ClassMember.Function, typer : Typer, options : list[PExpr]) : void
     {
       unless(method.Attributes %&& NemerleAttributes.Static)
         Message.Error(method.Location, "Attached property method should be static.");
@@ -228,7 +233,7 @@ namespace Nemerle.WPF
 
       method.Body = <[
                     $(CheckArgumentNull(<[ $(parameterName : dyn) ]>));
-        $(MakeGetValue(<[ $(parameterName : dyn) ]>, propertyName, propertyType));
+        $(MakeGetValue(<[ $(parameterName : dyn) ]>, propertyName, propertyType, typer));
       ]>;
 
       def setter = <[decl:


### PR DESCRIPTION
please consider the following snippet:

class Test : DependencyObject
{  
    [DependencyProperty]
    public ObjectValue : object
    { get; set; }
}

it produces these warnins during compilation:

Warning: N10001: there is no check needed to cast object to object
Warning: hint: consider using : instead of :>

don't know if proposed fix is the best way but it seems to work
