### PR TITLE
Fix issue #93

### DIFF
--- a/lib/list.n
+++ b/lib/list.n
@@ -990,7 +990,7 @@ namespace Nemerle.Collections
       match ((a, b)) {
         | ([], []) => ()
         | (x :: xs, y :: ys) => f (x, y); Iter2 (xs, ys, f)
-        | _ => throw System.ArgumentException ("NList.Iter2")
+        | _ => ()
       }
     }
 
@@ -1651,4 +1651,4 @@ namespace Nemerle.Collections
     }
   } /* end of module NList */
 } /* end of namespace Nemerle.Collections */
-
+ 


### PR DESCRIPTION
Do not throw exception in NList.Iter2.

The corresponding test:

using System.Console;
using Nemerle.Collections;

module Program
{
  Main() : void
  {
    def f(a, b) { WriteLine($"$a $b"); }
    NList.Iter2([], [], f);
    NList.Iter2([], [1], f);
    NList.Iter2([1], [], f);
    NList.Iter2([1, 2], [3, 4, 5], f);
  }
}

/*
BEGIN-OUTPUT
1 3
2 4
END-OUTPUT
*/

P.S.
I didn't manage to push to my fork.. Don't have time to check it now.
