### PR TITLE
Incorrect delegate signature reconstruction

### DIFF
--- a/VsIntegration/Nemerle.Compiler.Utils/Nemerle.Completion2/CodeModel/SourceGenerator.n
+++ b/VsIntegration/Nemerle.Compiler.Utils/Nemerle.Completion2/CodeModel/SourceGenerator.n
@@ -423,12 +423,8 @@ namespace Nemerle.Completion2
       {
       | (m is IMethod) :: _ =>
         Write("(");
-        m.GetParameters().Iter(p =>
-          {
-            Write(p.Name);
-            Write(" : ");
-            WriteType(p.ty);
-          });
+        def (from, _) = GetSignature(m);
+        WriteParameterDeclarations(m, from);
         Write(") : ");
         WriteType(m.ReturnType);
       | _                   => ();

--- a/snippets/VS2010/Nemerle.Compiler.Utils/Nemerle.Completion2/CodeModel/SourceGenerator.n
+++ b/snippets/VS2010/Nemerle.Compiler.Utils/Nemerle.Completion2/CodeModel/SourceGenerator.n
@@ -423,12 +423,8 @@ namespace Nemerle.Completion2
       {
       | (m is IMethod) :: _ =>
         Write("(");
-        m.GetParameters().Iter(p =>
-          {
-            Write(p.Name);
-            Write(" : ");
-            WriteType(p.ty);
-          });
+        def (from, _) = GetSignature(m);
+        WriteParameterDeclarations(m, from);
         Write(") : ");
         WriteType(m.ReturnType);
       | _                   => ();


### PR DESCRIPTION
1. Create console application
2. Add "public event Event : EventHandler;" to the Program module
3. Press F12 ("Go To Definition") on "EventHandler"

Note incorrect parameters concatenation in the EventHandler signature:

public delegate System.EventHandler (sender : objecte : System.EventArgs) : void;
