### PR TITLE
[StructuralEquality] Added support for variant options

### DIFF
--- a/macros/StructuralEquality.n
+++ b/macros/StructuralEquality.n
@@ -59,13 +59,13 @@ namespace Nemerle.Extensions
     {
       def type = GetTypeName(tb);
 
-      // hack! but Nemerle doesn't build without it
-      unless (tb.FullName == "Nemerle.Builtins.Tuple")
+      // Nemerle doesn't build if Tuples from stdlib are changed
+      unless (tb.FullName == "Nemerle.Builtins.Tuple" || tb.IsVariantOption)
       {
         tb.AddImplementedInterface(<[ System.IEquatable.[$type] ]>);
         tb.UserData.Add(IsEquatableImplementedLabel, true);
         
-        // only .NET 4.0+ supports this
+        // .NET 4.0 only
         unless (tb.Manager.Lookup("System.Collections.IStructuralEquatable") is null)
         {          
           tb.AddImplementedInterface(<[ System.Collections.IStructuralEquatable ]>);
@@ -342,10 +342,17 @@ namespace Nemerle.Extensions
       | HalfId(n) => PExpr.Ref(n)
       | Expression(e) => e
       }
-        
+      
       def qname = PExpr.FromQualifiedIdentifier(tb.Manager, tb.Ast.FullQualifiedName);
-      def args = tb.Ast.DeclaredTypeParameters.tyvars.Map(splicable_to_ref);
-      <[ $qname.[..$args] ]>
+      if (tb.Ast.DeclaredTypeParameters is null)
+      {
+        <[ $qname ]>
+      }
+      else
+      {
+        def args = tb.Ast.DeclaredTypeParameters.tyvars.Map(splicable_to_ref);
+        <[ $qname.[..$args] ]>
+      }
     }
       
     AskUserData(tb : TypeBuilder, question : string, defaultAnswer : bool = false) : bool

--- a/macros/StructuralEquality.n
+++ b/macros/StructuralEquality.n
@@ -29,7 +29,7 @@ namespace Nemerle.Extensions
   {
     StructuralEqualityImpl.RunWithTypedMembers(tb, options);
   }
-    
+
   [Nemerle.MacroUsage (Nemerle.MacroPhase.BeforeInheritance,
     Nemerle.MacroTargets.Field,
     Inherited = false, AllowMultiple = false)]
@@ -37,7 +37,7 @@ namespace Nemerle.Extensions
   {
     StructuralEqualityImpl.Ignore(tb, field);
   }
-    
+
   [Nemerle.MacroUsage (Nemerle.MacroPhase.BeforeInheritance,
     Nemerle.MacroTargets.Property,
     Inherited = false, AllowMultiple = false)]
@@ -45,7 +45,7 @@ namespace Nemerle.Extensions
   {
     StructuralEqualityImpl.Ignore(tb, prop);
   }
-  
+
   module StructuralEqualityImpl
   {
     // used as keys in UserData
@@ -64,10 +64,10 @@ namespace Nemerle.Extensions
       {
         tb.AddImplementedInterface(<[ System.IEquatable.[$type] ]>);
         tb.UserData.Add(IsEquatableImplementedLabel, true);
-        
-        // .NET 4.0 only
-        unless (tb.Manager.Lookup("System.Collections.IStructuralEquatable") is null)
-        {          
+
+        // only .NET 4.0+ supports this
+        when (tb.Manager.NameTree.LookupExactType("System.Collections.IStructuralEquatable").IsSome)
+        {
           tb.AddImplementedInterface(<[ System.Collections.IStructuralEquatable ]>);
           tb.UserData.Add(IsStructuralEquatableImplementedLabel, true);
         }
@@ -76,30 +76,30 @@ namespace Nemerle.Extensions
 
     // parses options, defines methods
     public RunWithTypedMembers(tb : TypeBuilder, options_expr : list[PExpr]) : void
-    {        
+    {
       def options = SEOptions.Parse(options_expr);
-        
+
       def get_relevant_fields()
-      {            
-        def all_fields = tb.GetFields(BindingFlags.Public %| 
-                                      BindingFlags.NonPublic %| 
-                                      BindingFlags.Instance %| 
+      {
+        def all_fields = tb.GetFields(BindingFlags.Public %|
+                                      BindingFlags.NonPublic %|
+                                      BindingFlags.Instance %|
                                       BindingFlags.DeclaredOnly);
-                  
-        // retrieve all ignored fields            
-        def ignore_fields = if (tb.UserData.Contains(IgnoredFieldsLabel)) 
+
+        // retrieve all ignored fields
+        def ignore_fields = if (tb.UserData.Contains(IgnoredFieldsLabel))
           tb.UserData[IgnoredFieldsLabel] :> List[string] else List();
 
         // ignored properties
         when (tb.UserData.Contains(IgnoredPropertiesLabel))
         {
           def prop_list = tb.UserData[IgnoredPropertiesLabel] :> List[string];
-                    
+
           foreach (prop in prop_list)
           {
             match (tb.LookupMember(prop).Find(x => x is IProperty))
             {
-            | Some(builder is PropertyBuilder) => 
+            | Some(builder is PropertyBuilder) =>
               match (builder.AutoPropertyField)
               {
               | Some(field) => ignore_fields.Add(field.Name)
@@ -109,40 +109,40 @@ namespace Nemerle.Extensions
             }
           }
         }
-                                
+
         ignore_fields.AddRange(options.IgnoreFields);
         ignore_fields.Sort();
-                
+
         // remove ignored fields and return result
         all_fields.Filter(x => ignore_fields.BinarySearch(x.Name) < 0);
       }
-            
+
       // fields that are not ignored when evaluating structural equality
       def relevant_fields = get_relevant_fields();
-            
+
       // true if strict type equality is needed, i. e. no subtypes are allowed;
       def typecheck_needed = !tb.IsSealed && !tb.IsValueType && options.CheckTypes;
-            
+
       DefineEquality(tb, relevant_fields, typecheck_needed);
       DefineHashCode(tb, relevant_fields);
       DefineOperators(tb);
       DefineStructural(tb);
     }
-    
+
     // adds a field to ignore list
     public Ignore(tb : TypeBuilder, field : ClassMember.Field) : void
     {
         unless (tb.UserData.Contains(IgnoredFieldsLabel)) tb.UserData.Add(IgnoredFieldsLabel, List.[string]());
-           
+
         def lst = tb.UserData[IgnoredFieldsLabel] :> List[string];
         unless (lst.Contains(field.Name)) lst.Add(field.Name);
     }
-        
+
     // adds a property to ignore list
     public Ignore(tb : TypeBuilder, prop : ClassMember.Property) : void
-    {           
+    {
         unless (tb.UserData.Contains(IgnoredPropertiesLabel)) tb.UserData.Add(IgnoredPropertiesLabel, List.[string]());
-           
+
         def lst = tb.UserData[IgnoredPropertiesLabel] :> List[string];
         unless (lst.Contains(prop.Name)) lst.Add(prop.Name);
     }
@@ -153,36 +153,36 @@ namespace Nemerle.Extensions
     {
         [Accessor] _ignoreFields : list[string];
         [Accessor] _checkTypes   : bool;
-            
+
         [Accessor] static _default : SEOptions = SEOptions([], true);
-            
+
         public static Parse(options : list[PExpr]) : SEOptions
         {
           mutable check_types = true;
           mutable ignore_fields = [];
-                
+
           foreach (opt in options)
           {
           | <[ CheckTypes = true ]> => check_types = true;
           | <[ CheckTypes = false ]> => check_types = false;
-                
-          | <[ Ignore = [..$flds] ]> 
+
+          | <[ Ignore = [..$flds] ]>
           | <[ Ignore = $fld  ]> with flds = [fld] =>
-                    
+
             // add field names as strings
             ignore_fields += flds.MapFiltered(_ is PExpr.Ref, x => (x :> PExpr.Ref).name.Id)
-                    
-          | _ => 
+
+          | _ =>
               Message.Error("Unknown options for StructuralEquality.")
           }
-                
+
           SEOptions(ignore_fields, check_types)
-        }            
+        }
     }
-    
+
     DefineEquality(tb : TypeBuilder, fields : Seq[IField], check_types : bool) : void
     {
-        
+
       // generates comparison code for a single field
       def invokeEquals(x : IField)
       {
@@ -191,28 +191,28 @@ namespace Nemerle.Extensions
           <[ $(nm : name) == other.$(nm : name) ]> // primitive magic
         else if (x.GetMemType() is FixedType.StaticTypeVarRef) // for type parameters
           <[ System.Object.Equals($(nm : name), other.$(nm : name)) ]>
-        else if (x.GetMemType().IsValueType) 
+        else if (x.GetMemType().IsValueType)
           <[ $(nm : name).Equals(other.$(nm : name)) ]> // no null-checks
         else
           <[ System.Object.Equals($(nm : name), other.$(nm : name)) ]>;
       }
 
       def type = GetTypeName(tb);
-      def type_checker = 
-        if (check_types) 
-          <[ other.GetType().Equals(this.GetType()) ]> 
-        else 
+      def type_checker =
+        if (check_types)
+          <[ other.GetType().Equals(this.GetType()) ]>
+        else
           <[ true ]>;
-                    
+
       // core comparison code (type checker + comparison for each field)
       def body = fields.Fold(type_checker, (f, acc) => <[ $(invokeEquals(f)) && $acc ]> );
-            
+
       // no null-check for structs
       def fun_body = if (tb.IsValueType) body else
         <[ match (other) { | null => false | _ => $body } ]>;
       def fun_body = <[
           _ = other; // shut the compiler up if body degrades to "true"
-          $fun_body            
+          $fun_body
       ]>;
 
       def implementsEquatable = AskUserData(tb, IsEquatableImplementedLabel);
@@ -229,7 +229,7 @@ namespace Nemerle.Extensions
       ]>);
 
       tb.Define(equals);
-            
+
       // implements object.Equals
       tb.Define(<[ decl:
         public override Equals (_other : System.Object) : bool
@@ -237,12 +237,12 @@ namespace Nemerle.Extensions
         | x is $type => Equals(x)
         | _ => false
         }
-      ]> |> MarkCompilerGenerated);        
+      ]> |> MarkCompilerGenerated);
     }
-        
+
     // uses http://en.wikipedia.org/wiki/Jenkins_hash_function to implement GetHashCode
     DefineHashCode(tb : TypeBuilder, fields : Seq[IField]) : void
-    {            
+    {
       def hash_body = fields.Map(f =>
       {
         def gethashcode =
@@ -252,14 +252,14 @@ namespace Nemerle.Extensions
             <[ if (System.Object.ReferenceEquals($(f.Name : usesite), null)) 0 else $(f.Name : usesite).GetHashCode(); ]>
           else
             <[ $(f.Name : usesite)?.GetHashCode() ]>;
-                
+
         <[
           hash += $gethashcode;
           hash += (hash << 10);
           hash ^= (hash >> 6);
         ]>
-      }); 
-            
+      });
+
       def body = if (hash_body is []) <[ 0 ]> else
       <[
         unchecked
@@ -272,14 +272,14 @@ namespace Nemerle.Extensions
           hash
         }
       ]>;
-            
+
       tb.Define (<[ decl: public override GetHashCode () : int { $body } ]> |> MarkCompilerGenerated);
     }
-        
+
     DefineOperators(tb : TypeBuilder) : void
     {
       def type = GetTypeName(tb);
-        
+
       if (tb.IsValueType)
       {
         tb.Define(<[ decl:
@@ -287,7 +287,7 @@ namespace Nemerle.Extensions
           {
               first.Equals(second)
           }
-        ]> |> MarkCompilerGenerated);  
+        ]> |> MarkCompilerGenerated);
       }
       else
       {
@@ -296,9 +296,9 @@ namespace Nemerle.Extensions
           {
               if (first is null) second is null else first.Equals(second)
           }
-        ]> |> MarkCompilerGenerated);  
+        ]> |> MarkCompilerGenerated);
       }
-            
+
       tb.Define(<[ decl:
         public static @!= (first : $type, second : $type) : bool
         {
@@ -306,10 +306,10 @@ namespace Nemerle.Extensions
         }
       ]> |> MarkCompilerGenerated);
     }
-      
+
     DefineStructural(tb : TypeBuilder) : void
     {
-      when (AskUserData(tb, IsStructuralEquatableImplementedLabel) == true) 
+      when (AskUserData(tb, IsStructuralEquatableImplementedLabel) == true)
       {
         tb.Define(<[ decl:
           public Equals(other : object, _comparer : System.Collections.IEqualityComparer) : bool
@@ -317,7 +317,7 @@ namespace Nemerle.Extensions
             Equals(other);
           }
         ]> |> MarkCompilerGenerated);
-        
+
         tb.Define(<[ decl:
           public GetHashCode(_comparer : System.Collections.IEqualityComparer) : int
           {
@@ -326,23 +326,23 @@ namespace Nemerle.Extensions
         ]> |> MarkCompilerGenerated);
       }
     }
-      
+
     MarkCompilerGenerated(cm : ClassMember) : ClassMember
     {
       cm.AddCustomAttribute(<[System.Runtime.CompilerServices.CompilerGenerated]>);
       cm
     }
-      
+
     // no api to get type name with params; 'this' keyword in this context is bugged
     GetTypeName(tb : TypeBuilder) : PExpr
     {
       def splicable_to_ref(s : Splicable)
       {
-      | Name(n) 
+      | Name(n)
       | HalfId(n) => PExpr.Ref(n)
       | Expression(e) => e
       }
-      
+
       def qname = PExpr.FromQualifiedIdentifier(tb.Manager, tb.Ast.FullQualifiedName);
       if (tb.Ast.DeclaredTypeParameters is null)
       {
@@ -354,7 +354,7 @@ namespace Nemerle.Extensions
         <[ $qname.[..$args] ]>
       }
     }
-      
+
     AskUserData(tb : TypeBuilder, question : string, defaultAnswer : bool = false) : bool
     {
       if (!tb.UserData.Contains(question)) defaultAnswer else tb.UserData[question] :> bool


### PR DESCRIPTION
Fixed compiler crash (and another error) preventing the use of StructuralEquality on variant options.
