### PR TITLE
Corrected FixedType.IsPrimitive

### DIFF
--- a/ncc/typing/MType.n
+++ b/ncc/typing/MType.n
@@ -650,7 +650,7 @@ namespace Nemerle.Compiler
         match (this) {
           | Class (tc, []) =>
             tc.IsEnum ||
-            tc.SystemType.IsPrimitive
+            tc.SystemType?.IsPrimitive
           | _ => false
         }
       }


### PR DESCRIPTION
Modified FixedType.IsPrimitive not to throw exceptions for non-system types.
