### PR TITLE
Looks like changes made for dispatching ncc32.exe/ncc64.exe calls has been lost. So I can't compile a Nemerle project with reference to x86 assembly on 64-bit Windows version

### DIFF
--- a/ncc/main.n
+++ b/ncc/main.n
@@ -40,6 +40,10 @@ using Nemerle.Utility;
 using Nemerle.IO;
 using Nemerle.Compiler;
 
+using System;
+using System.Diagnostics;
+using System.Reflection;
+
 namespace Nemerle.CommandlineCompiler
 {
   module MainClass
@@ -48,47 +52,77 @@ namespace Nemerle.CommandlineCompiler
     mutable Manager : ManagerClass;
     mutable Options : CompilationOptions;
 
-    public Main () : void
+    public Main() : void
     {
-      Options = CompilationOptions ();
-      Manager = ManagerClass (Options);
-      Manager.InitOutput (System.Console.Out);
-      parse_command_line ();
-      if (stack_kilos != 0 || needs_bigger_stack ()) {
+      def is64bitProcess = IntPtr.Size == 8;
+      Options = CompilationOptions();
+      Manager = ManagerClass(Options);
+      Manager.InitOutput(Console.Out);
+      parse_command_line();
+
+      def runInAppropriateProcess(processName : string) : void
+      {
+        def dir = IO.Path.GetDirectoryName(Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
+        def path = IO.Path.Combine(dir, processName);
+        def argsList = Environment.GetCommandLineArgs().NToList();
+        def args = $<#..$(argsList.Tail; " ")#>;
+        def process = Process();
+        process.StartInfo.UseShellExecute = false;
+        process.StartInfo.CreateNoWindow = false;
+        process.StartInfo.FileName = path;
+        process.StartInfo.Arguments = args;
+        if (process.Start())
+        {
+          process.WaitForExit();
+          when (process.ExitCode != 0)
+            Environment.Exit(process.ExitCode);
+        }
+        else
+          Environment.Exit(-1);
+      }
+      def eq(a, b) { string.Equals(a, b, StringComparison.InvariantCultureIgnoreCase) }
+
+      if (eq(Options.Platform, "x86") && is64bitProcess)
+        runInAppropriateProcess("ncc32.exe")
+      else if (eq(Options.Platform, "x64") && !is64bitProcess)
+        runInAppropriateProcess("ncc64.exe")
+      else if (stack_kilos != 0 || needs_bigger_stack())
+      {
         when (stack_kilos == 0)
-          stack_kilos = 20 * 1024 * if (System.IntPtr.Size == 8) 8 else 1;
-        def thread = System.Threading.Thread (main_with_catching, stack_kilos * 1024);
+          stack_kilos = 20 * 1024 * if (is64bitProcess) 8 else 1;
+        def thread = Threading.Thread(main_with_catching, stack_kilos * 1024);
         thread.Name = "Main compiler thread";
-        thread.Start ();
-        thread.Join ();
-      } else
-        main_with_catching ()
+        thread.Start();
+        thread.Join();
+      }
+      else
+        main_with_catching()
     }
     
-    needs_bigger_stack () : bool
+    needs_bigger_stack() : bool
     {
-      typeof (object).Assembly.GetType ("System.RuntimeType") != null
+      typeof(object).Assembly.GetType("System.RuntimeType") != null
     }
 
-    main_with_catching () : void
+    main_with_catching() : void
     {
       try
       {
-        Options.LibraryPaths ::= System.IO.Path.GetDirectoryName
-          (System.Uri (typeof (MainClass).Assembly.CodeBase).LocalPath);
+        Options.LibraryPaths ::= IO.Path.GetDirectoryName
+          (Uri(typeof(MainClass).Assembly.CodeBase).LocalPath);
 
         // run compilation with already created options
         Manager.Run ()
       }
       catch
       {
-        | e is System.IO.FileNotFoundException =>
+        | e is IO.FileNotFoundException =>
           Message.Error (e.Message)
         | e is Recovery =>
           bomb (e, "got Recovery exception")
         | e is BailOutException =>
           bomb (e, "got bail out exception")
-        | e is System.ArgumentException =>
+        | e is ArgumentException =>
           bomb (e, "got ArgumentException (" + e.Message + ")")
         | e is MatchFailureException =>
           bomb (e, "got MatchFailureException exception")
@@ -97,7 +131,7 @@ namespace Nemerle.CommandlineCompiler
         | e is AssertionException =>
           bomb (e, e.Message)
         | _ is AssemblyFindException =>
-          System.Environment.Exit (3);
+          Environment.Exit (3);
         | e =>
           bomb (e, $ "got some unknown exception of type $(e.GetType()): $(e.Message)")
       }
@@ -105,15 +139,15 @@ namespace Nemerle.CommandlineCompiler
       Message.MaybeBailout();
     }
     
-    bomb (e : System.Exception, msg : string) : void
+    bomb (e : Exception, msg : string) : void
     {
       Manager.KillProgressBar ();
       Message.MaybeBailout (true);
       Message.Error (sprintf ("internal compiler error: %s\n%s\n", msg, e.StackTrace));
-      System.Environment.Exit (2);
+      Environment.Exit(2);
     }
 
-    parse_command_line () : void
+    parse_command_line() : void
     {
       def cOptions = Options;
 
@@ -123,23 +157,24 @@ namespace Nemerle.CommandlineCompiler
       {
         def compilerAssembly = typeof(ManagerClass).Assembly;
         def version = compilerAssembly.GetName().Version;
-        def copyright = (compilerAssembly.GetCustomAttributes(typeof(System.Reflection.AssemblyCopyrightAttribute), false)[0]
-            :> System.Reflection.AssemblyCopyrightAttribute).Copyright;
-        System.Console.Error.Write(
+        def copyright = (compilerAssembly.GetCustomAttributes(typeof(Reflection.AssemblyCopyrightAttribute), false)[0]
+            :> Reflection.AssemblyCopyrightAttribute).Copyright;
+        Console.Error.Write(
           $ "Nemerle Compiler (ncc) version $version (SVN)\n"
             "$copyright \n"
             "All rights reserved.\n");
-        System.Environment.Exit (0);
+        Environment.Exit (0);
       }
 
       mutable help_opts = [];
       def print_help ()
       {
-        System.Console.WriteLine (Getopt.Usage (help_opts));
-        System.Environment.Exit (0);
+        Console.WriteLine (Getopt.Usage (help_opts));
+        Environment.Exit (0);
       }
 
-      def opts = cOptions.GetCommonOptions () + [
+      def opts = cOptions.GetCommonOptions()
+      + [
         Getopt.CliOption.Int (name = "-stack-size",
                      aliases = [],
                      help = "Set stack size of the compiler to INT megabytes",
@@ -153,25 +188,23 @@ namespace Nemerle.CommandlineCompiler
                      help = "Output version information and exit",
                      handler = print_version),
         Getopt.CliOption.Flag (name = "-help",
-                     aliases = ["-h"],
+                     aliases = ["-h", "-?"],
                      help = "Display this usage message and exit",
                      handler = print_help),
-#if DEBUG
         Getopt.CliOption.Flag (name = "-debugger",
                      aliases = [],
                      help = "Display assert dialog for user can start debug session",
-                     handler = () => System.Diagnostics.Debug.Assert(false, 
+                     handler = () => Diagnostics.Debug.Assert(false, 
                       "Press Retry to start debug session. "
                       "If you wants to see this dialog at next time you should "
                       "remove '-debugger' option from command line")),
-#endif
         Getopt.CliOption.NonOption (name = "",
                           help = "Specify file to compile",
                           handler = fun (s) { files = s :: files })
       ];
       help_opts = opts;
 
-      Getopt.Parse (opts);
+      Getopt.Parse(opts);
 
       match (files) {
         | [] =>


### PR DESCRIPTION
Repair changes introduced by this commit: https://github.com/rsdn/nemerle/commit/cbabf189053c96827d4bf827d3e7d6a9aea9a580#ncc/main.n

Commit description:
[ncc] Added ncc32.exe and ncc64.exe. When the ncc.exe compile for specific platform it's run the ncc32.exe for x86 platform and ncc64.exe for x64 platform.

Details:
http://www.rsdn.ru/forum/nemerle/4331845.aspx
