### PR TITLE
Fixes #188

### DIFF
--- a/Linq/Macro/Properties/AssemblyInfo.n
+++ b/Linq/Macro/Properties/AssemblyInfo.n
@@ -8,7 +8,6 @@ using Nemerle.Utility;
 // associated with an assembly.
 
 [assembly: AssemblyTitle("Nemerle Linq Macro")]
-[assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Nemerle Linq Macro")]

--- a/ncc/external/InternalTypes.n
+++ b/ncc/external/InternalTypes.n
@@ -35,168 +35,168 @@ using SR = System.Reflection;
 
 namespace Nemerle.Compiler {
 
-[ManagerAccess]
-public class SystemTypeClass
-{
-  public mutable Array                                     : System.Type;
-  public mutable Boolean                                   : System.Type;
-  public mutable Byte                                      : System.Type;
-  public mutable Char                                      : System.Type;
-  public mutable Decimal                                   : System.Type;
-  public mutable Double                                    : System.Type;
-  public mutable Enum                                      : System.Type;
-  public mutable FlagsAttribute                            : System.Type;
-  public mutable Int16                                     : System.Type;
-  public mutable Int32                                     : System.Type;
-  public mutable Int64                                     : System.Type;
-  public mutable IntPtr                                    : System.Type;
-  public mutable Delegate                                  : System.Type;
-  public mutable MulticastDelegate                         : System.Type;
-  public mutable Object                                    : System.Type;
-  public mutable Reflection_AssemblyConfigurationAttribute : System.Type;
-  public mutable Reflection_FieldInfo                      : System.Type;
-  public mutable Reflection_PropertyInfo                   : System.Type;
-  public mutable Reflection_DefaultMemberAttribute         : System.Type;
-  public mutable Runtime_CompilerServices_IsVolatile       : System.Type;
-  public mutable DebuggableAttribute                       : System.Type;
-  public mutable DebuggableAttribute_DebuggingModes        : System.Type;
-  public mutable CompilationRelaxationsAttribute           : System.Type;
-  public mutable SByte                                     : System.Type;
-  public mutable Single                                    : System.Type;
-  public mutable String                                    : System.Type;
-  public mutable Type                                      : System.Type;
-  public mutable UInt16                                    : System.Type;
-  public mutable UInt32                                    : System.Type;
-  public mutable UInt64                                    : System.Type;
-  public mutable Void                                      : System.Type;
-  public mutable ParamArrayAttribute                       : System.Type;
+  [ManagerAccess]
+  public class SystemTypeClass
+  {
+    public mutable Array                                     : System.Type;
+    public mutable Boolean                                   : System.Type;
+    public mutable Byte                                      : System.Type;
+    public mutable Char                                      : System.Type;
+    public mutable Decimal                                   : System.Type;
+    public mutable Double                                    : System.Type;
+    public mutable Enum                                      : System.Type;
+    public mutable FlagsAttribute                            : System.Type;
+    public mutable Int16                                     : System.Type;
+    public mutable Int32                                     : System.Type;
+    public mutable Int64                                     : System.Type;
+    public mutable IntPtr                                    : System.Type;
+    public mutable Delegate                                  : System.Type;
+    public mutable MulticastDelegate                         : System.Type;
+    public mutable Object                                    : System.Type;
+    public mutable Reflection_AssemblyConfigurationAttribute : System.Type;
+    public mutable Reflection_FieldInfo                      : System.Type;
+    public mutable Reflection_PropertyInfo                   : System.Type;
+    public mutable Reflection_DefaultMemberAttribute         : System.Type;
+    public mutable Runtime_CompilerServices_IsVolatile       : System.Type;
+    public mutable DebuggableAttribute                       : System.Type;
+    public mutable DebuggableAttribute_DebuggingModes        : System.Type;
+    public mutable CompilationRelaxationsAttribute           : System.Type;
+    public mutable SByte                                     : System.Type;
+    public mutable Single                                    : System.Type;
+    public mutable String                                    : System.Type;
+    public mutable Type                                      : System.Type;
+    public mutable UInt16                                    : System.Type;
+    public mutable UInt32                                    : System.Type;
+    public mutable UInt64                                    : System.Type;
+    public mutable Void                                      : System.Type;
+    public mutable ParamArrayAttribute                       : System.Type;
 
   // set in LibrariesLoader upon first possiblity
-  public mutable ExtensionAttribute                        : System.Type;
-  public mutable ExtensionAttributeAssembly                : string;
-  public mutable SQ_ExtensionAttribute                     : System.Type;
-  public mutable SQ_ExtensionAttributeAssembly             : string;
+    public mutable ExtensionAttribute                        : System.Type;
+    public mutable ExtensionAttributeAssembly                : string;
+    public mutable SQ_ExtensionAttribute                     : System.Type;
+    public mutable SQ_ExtensionAttributeAssembly             : string;
 
-  public mutable Decimal_ctors                             : Hashtable [string, SR.ConstructorInfo];
-  public mutable Type_GetTypeFromHandle                    : SR.MethodInfo;
-  public mutable MethodBase_GetMethodFromHandle            : SR.MethodInfo;
-  public mutable MethodBase_GetMethodFromHandle2           : SR.MethodInfo;
-  public mutable FieldInfo_GetFieldFromHandle              : SR.MethodInfo;
-  public mutable FieldInfo_GetFieldFromHandle2             : SR.MethodInfo;
-  public mutable AssemblyBuilder_EmbedResourceFile         : SR.MethodInfo;
-  public mutable String_opEquality                         : SR.MethodInfo;
-  public mutable String_opInequality                       : SR.MethodInfo;
-  public mutable Decimal_opEquality                        : SR.MethodInfo;
-  public mutable String_Concat                             : SR.MethodInfo;
-  public mutable ObjectCtor                                : SR.ConstructorInfo;
-  public mutable Delegate_Combine                          : SR.MethodInfo;
-  public mutable Delegate_Remove                           : SR.MethodInfo;
+    public mutable Decimal_ctors                             : Hashtable [string, SR.ConstructorInfo];
+    public mutable Type_GetTypeFromHandle                    : SR.MethodInfo;
+    public mutable MethodBase_GetMethodFromHandle            : SR.MethodInfo;
+    public mutable MethodBase_GetMethodFromHandle2           : SR.MethodInfo;
+    public mutable FieldInfo_GetFieldFromHandle              : SR.MethodInfo;
+    public mutable FieldInfo_GetFieldFromHandle2             : SR.MethodInfo;
+    public mutable AssemblyBuilder_EmbedResourceFile         : SR.MethodInfo;
+    public mutable String_opEquality                         : SR.MethodInfo;
+    public mutable String_opInequality                       : SR.MethodInfo;
+    public mutable Decimal_opEquality                        : SR.MethodInfo;
+    public mutable String_Concat                             : SR.MethodInfo;
+    public mutable ObjectCtor                                : SR.ConstructorInfo;
+    public mutable Delegate_Combine                          : SR.MethodInfo;
+    public mutable Delegate_Remove                           : SR.MethodInfo;
 
-  public NemerleAttribute : System.Type
-  {
+    public NemerleAttribute : System.Type
+    {
     mutable nemerle_attribute : System.Type;
 
-    get
-    {
-      when (nemerle_attribute == null)
-        InternalType.InitNemerleTypes ();
+      get
+      {
+        when (nemerle_attribute == null)
+          InternalType.InitNemerleTypes ();
 
-      nemerle_attribute
-    }
+        nemerle_attribute
+      }
 
     internal set { nemerle_attribute = value; }
-  }
+    }
 
-  public NullMatchException : System.Type
-  {
-    get { InternalType.NullMatchException_tc.SystemType }
-  }
+    public NullMatchException : System.Type
+    {
+      get { InternalType.NullMatchException_tc.SystemType }
+    }
 
-  public ContainsMacroAttribute : System.Type
-  {
-    get { InternalType.ContainsMacroAttribute_tc.SystemType }
-  }
+    public ContainsMacroAttribute : System.Type
+    {
+      get { InternalType.ContainsMacroAttribute_tc.SystemType }
+    }
 
-  public VariantAttribute : System.Type
-  {
-    get { InternalType.VariantAttribute_tc.SystemType }
-  }
+    public VariantAttribute : System.Type
+    {
+      get { InternalType.VariantAttribute_tc.SystemType }
+    }
 
-  public VariantOptionAttribute : System.Type
-  {
-    get { InternalType.VariantOptionAttribute_tc.SystemType }
-  }
+    public VariantOptionAttribute : System.Type
+    {
+      get { InternalType.VariantOptionAttribute_tc.SystemType }
+    }
 
-  public VolatileModifier : System.Type
-  {
-    get { InternalType.VolatileModifier_tc.SystemType }
-  }
+    public VolatileModifier : System.Type
+    {
+      get { InternalType.VolatileModifier_tc.SystemType }
+    }
 
-  public ImmutableAttribute : System.Type
-  {
-    get { InternalType.ImmutableAttribute_tc.SystemType }
-  }
+    public ImmutableAttribute : System.Type
+    {
+      get { InternalType.ImmutableAttribute_tc.SystemType }
+    }
 
-  public ConstantVariantOptionAttribute : System.Type
-  {
-    get { InternalType.ConstantVariantOptionAttribute_tc.SystemType }
-  }
+    public ConstantVariantOptionAttribute : System.Type
+    {
+      get { InternalType.ConstantVariantOptionAttribute_tc.SystemType }
+    }
 
-  public TypeAliasAttribute : System.Type
-  {
-    get { InternalType.TypeAliasAttribute_tc.SystemType }
-  }
+    public TypeAliasAttribute : System.Type
+    {
+      get { InternalType.TypeAliasAttribute_tc.SystemType }
+    }
 
-  public ExtensionPatternEncodingAttribute : System.Type
-  {
-    get { InternalType.ExtensionPatternEncodingAttribute_tc.SystemType }
-  }
+    public ExtensionPatternEncodingAttribute : System.Type
+    {
+      get { InternalType.ExtensionPatternEncodingAttribute_tc.SystemType }
+    }
 
   /**
    * Reflects a type using NamespaceTree
    */
-  public Reflect (type_name : string) : System.Type
-  {
-    match (Manager.NameTree.LookupSystemType (type_name)) {
-      | Some (t) => t
-      | _ => Util.ice ("cannot reflect `" + type_name + "'")
+    public Reflect (type_name : string) : System.Type
+    {
+      match (Manager.NameTree.LookupSystemType (type_name)) {
+        | Some (t) => t
+        | _ => Util.ice ("cannot reflect `" + type_name + "'")
+      }
     }
-  }
 
-  internal Init () : void
-  {
-    Array = Reflect ("System.Array");
-    Boolean = Reflect ("System.Boolean");
-    Byte = Reflect ("System.Byte");
-    Char = Reflect ("System.Char");
-    Decimal = Reflect ("System.Decimal");
-    Double = Reflect ("System.Double");
-    Enum = Reflect ("System.Enum");
-    FlagsAttribute = Reflect ("System.FlagsAttribute");
-    Int16 = Reflect ("System.Int16");
-    Int32 = Reflect ("System.Int32");
-    Int64 = Reflect ("System.Int64");
-    IntPtr = Reflect ("System.IntPtr");
-    Delegate = Reflect ("System.Delegate");
-    MulticastDelegate = Reflect ("System.MulticastDelegate");
-    Object = Reflect ("System.Object");
-    Reflection_FieldInfo = Reflect ("System.Reflection.FieldInfo");
-    Reflection_PropertyInfo = Reflect ("System.Reflection.PropertyInfo");
-    Reflection_AssemblyConfigurationAttribute = Reflect ("System.Reflection.AssemblyConfigurationAttribute");
-    Runtime_CompilerServices_IsVolatile = Reflect ("System.Runtime.CompilerServices.IsVolatile");
-    DebuggableAttribute = Reflect ("System.Diagnostics.DebuggableAttribute");
-    DebuggableAttribute_DebuggingModes = Reflect ("System.Diagnostics.DebuggableAttribute.DebuggingModes");
-    CompilationRelaxationsAttribute = Reflect ("System.Runtime.CompilerServices.CompilationRelaxationsAttribute");
-    SByte = Reflect ("System.SByte");
-    Single = Reflect ("System.Single");
-    String = Reflect ("System.String");
-    SystemTypeCache.Type = Reflect ("System.Type");
-    UInt16 = Reflect ("System.UInt16");
-    UInt32 = Reflect ("System.UInt32");
-    UInt64 = Reflect ("System.UInt64");
-    Void = Reflect ("System.Void");
-    ParamArrayAttribute = Reflect ("System.ParamArrayAttribute");
-    Reflection_DefaultMemberAttribute = Reflect ("System.Reflection.DefaultMemberAttribute");
+    internal Init () : void
+    {
+      Array = Reflect ("System.Array");
+      Boolean = Reflect ("System.Boolean");
+      Byte = Reflect ("System.Byte");
+      Char = Reflect ("System.Char");
+      Decimal = Reflect ("System.Decimal");
+      Double = Reflect ("System.Double");
+      Enum = Reflect ("System.Enum");
+      FlagsAttribute = Reflect ("System.FlagsAttribute");
+      Int16 = Reflect ("System.Int16");
+      Int32 = Reflect ("System.Int32");
+      Int64 = Reflect ("System.Int64");
+      IntPtr = Reflect ("System.IntPtr");
+      Delegate = Reflect ("System.Delegate");
+      MulticastDelegate = Reflect ("System.MulticastDelegate");
+      Object = Reflect ("System.Object");
+      Reflection_FieldInfo = Reflect ("System.Reflection.FieldInfo");
+      Reflection_PropertyInfo = Reflect ("System.Reflection.PropertyInfo");
+      Reflection_AssemblyConfigurationAttribute = Reflect ("System.Reflection.AssemblyConfigurationAttribute");
+      Runtime_CompilerServices_IsVolatile = Reflect ("System.Runtime.CompilerServices.IsVolatile");
+      DebuggableAttribute = Reflect ("System.Diagnostics.DebuggableAttribute");
+      DebuggableAttribute_DebuggingModes = Reflect ("System.Diagnostics.DebuggableAttribute.DebuggingModes");
+      CompilationRelaxationsAttribute = Reflect ("System.Runtime.CompilerServices.CompilationRelaxationsAttribute");
+      SByte = Reflect ("System.SByte");
+      Single = Reflect ("System.Single");
+      String = Reflect ("System.String");
+      SystemTypeCache.Type = Reflect ("System.Type");
+      UInt16 = Reflect ("System.UInt16");
+      UInt32 = Reflect ("System.UInt32");
+      UInt64 = Reflect ("System.UInt64");
+      Void = Reflect ("System.Void");
+      ParamArrayAttribute = Reflect ("System.ParamArrayAttribute");
+      Reflection_DefaultMemberAttribute = Reflect ("System.Reflection.DefaultMemberAttribute");
 
     {
       Decimal_ctors = Hashtable ();
@@ -211,506 +211,519 @@ public class SystemTypeClass
       assert (Decimal_ctors.Count >=  7)
     }
 
-    Type_GetTypeFromHandle = SystemTypeCache.Type.GetMethod ("GetTypeFromHandle");
-    MethodBase_GetMethodFromHandle  = typeof(SR.MethodBase).GetMethod("GetMethodFromHandle", array[typeof(System.RuntimeMethodHandle)]);
-    MethodBase_GetMethodFromHandle2 = typeof(SR.MethodBase).GetMethod("GetMethodFromHandle", array[typeof(System.RuntimeMethodHandle), typeof(System.RuntimeTypeHandle)]);
-    FieldInfo_GetFieldFromHandle    = typeof(SR.FieldInfo) .GetMethod("GetFieldFromHandle",  array[typeof(System.RuntimeFieldHandle)]);
-    FieldInfo_GetFieldFromHandle2   = typeof(SR.FieldInfo) .GetMethod("GetFieldFromHandle",  array[typeof(System.RuntimeFieldHandle),  typeof(System.RuntimeTypeHandle)]);
-    AssemblyBuilder_EmbedResourceFile = Reflect ("System.Reflection.Emit.AssemblyBuilder")
-      .GetMethod ("EmbedResourceFile", SR.BindingFlags.Instance %| SR.BindingFlags.Public
-                   %| BindingFlags.NonPublic, null, SR.CallingConventions.Any,
-                   array [String, String], null);
-    String_opEquality = SystemTypeCache.String.GetMethod ("op_Equality");
-    String_opInequality = SystemTypeCache.String.GetMethod ("op_Inequality");
-    String_Concat = String.GetMethod ("Concat", array [String, String]);
-    Decimal_opEquality = SystemTypeCache.Decimal.GetMethod ("op_Equality");
-    ObjectCtor = Object.GetConstructor (System.Type.EmptyTypes);
-    assert (ObjectCtor != null);
+      Type_GetTypeFromHandle = SystemTypeCache.Type.GetMethod ("GetTypeFromHandle");
+      MethodBase_GetMethodFromHandle  = typeof(SR.MethodBase).GetMethod("GetMethodFromHandle", array[typeof(System.RuntimeMethodHandle)]);
+      MethodBase_GetMethodFromHandle2 = typeof(SR.MethodBase).GetMethod("GetMethodFromHandle", array[typeof(System.RuntimeMethodHandle), typeof(System.RuntimeTypeHandle)]);
+      FieldInfo_GetFieldFromHandle    = typeof(SR.FieldInfo) .GetMethod("GetFieldFromHandle",  array[typeof(System.RuntimeFieldHandle)]);
+      FieldInfo_GetFieldFromHandle2   = typeof(SR.FieldInfo) .GetMethod("GetFieldFromHandle",  array[typeof(System.RuntimeFieldHandle),  typeof(System.RuntimeTypeHandle)]);
+      AssemblyBuilder_EmbedResourceFile = Reflect ("System.Reflection.Emit.AssemblyBuilder")
+                                             .GetMethod ("EmbedResourceFile", SR.BindingFlags.Instance %| SR.BindingFlags.Public
+                                                         %| BindingFlags.NonPublic, null, SR.CallingConventions.Any,
+                                                         array [String, String], null);
+      String_opEquality = SystemTypeCache.String.GetMethod ("op_Equality");
+      String_opInequality = SystemTypeCache.String.GetMethod ("op_Inequality");
+      String_Concat = String.GetMethod ("Concat", array [String, String]);
+      Decimal_opEquality = SystemTypeCache.Decimal.GetMethod ("op_Equality");
+      ObjectCtor = Object.GetConstructor (System.Type.EmptyTypes);
+      assert (ObjectCtor != null);
 
-    Delegate_Combine = Delegate.GetMethod ("Combine", array [Delegate, Delegate]);
-    Delegate_Remove = Delegate.GetMethod ("Remove", array [Delegate, Delegate]);
-  }
+      Delegate_Combine = Delegate.GetMethod ("Combine", array [Delegate, Delegate]);
+      Delegate_Remove = Delegate.GetMethod ("Remove", array [Delegate, Delegate]);
+    }
 
-  internal this (man : ManagerClass)
-  {
-    Manager = man;
-  }
-}
-
-public class TupleType
-{
-  internal tycon : TypeInfo;
-  internal fields : array [IField];
-  internal ctor : IMethod;
-
-  public GetField (pos : int) : IField
-  {
-    fields [pos]
-  }
-
-  public Ctor : IMethod
-  {
-    get { ctor }
-  }
-
-  public TyCon : TypeInfo
-  {
-    get { tycon }
-  }
-
-  public static Make (ty : TypeVar) : FixedType.Class
-  {
-    match (ty.Fix ()) {
-      | Tuple (types) =>
-        def inst = ty.Manager.InternalType.GetTupleType (types.Length);
-        FixedType.Class (inst.tycon, types)
-      | _ => Util.ice ()
+    internal this (man : ManagerClass)
+    {
+      Manager = man;
     }
   }
 
-  get_field (pos : int) : IField
+  public class TupleType
   {
-    match (tycon.LookupMember (sprintf ("Field%d", pos - 1))) {
-      | [x] => x :> IField
-      | _ => assert (false)
+    internal tycon : TypeInfo;
+    internal fields : array [IField];
+    internal ctor : IMethod;
+
+    public GetField (pos : int) : IField
+    {
+      fields [pos]
     }
-  }
 
-  static name = ["Nemerle", "Builtins", "Tuple"] : list [string];
-
-  public static IsTupleMember (ty : IMember) : bool
-  {
-    def dt = ty.DeclaringType;
-    def typarmsCount = dt.TyparmsCount;
-    typarmsCount > 1 && dt.Equals (dt.Manager.InternalType.GetTupleType (typarmsCount).tycon)
-  }
-
-  internal this (m : ManagerClass, size : int)
-  {
-    tycon = m.NameTree.LookupInternalType (name, size);
-    fields = array (size + 1);
-    for (mutable i = 1; i <= size; ++i)
-      fields [i] = get_field (i);
-    ctor = tycon.LookupMember (".ctor").Head :> IMethod;
-  }
-}
-
-public class FunctionType {
-  internal tycon : TypeInfo;
-  internal void_tycon : TypeInfo;
-  internal apply : IMethod;
-  internal apply_void : IMethod;
-  internal apply_tupled : IMethod;
-  internal apply_tupled_void : IMethod;
-
-  public ApplyMethod : IMethod
-  {
-    get { apply }
-  }
-
-  public ApplyVoidMethod : IMethod
-  {
-    get { apply_void }
-  }
-
-  public TyCon : TypeInfo
-  {
-    get { tycon }
-  }
-
-  public VoidTyCon : TypeInfo
-  {
-    get { void_tycon }
-  }
-
-  public FromTupleTyCon : TypeInfo;
-  public FromTupleVoidTyCon : TypeInfo;
-  public FromTupleCtor : IMethod;
-  public FromTupleVoidCtor : IMethod;
-
-  public GetMethodWithReturnType (ret_type : TypeVar) : IMethod
-  {
-    if (ret_type.Fix () is FixedType.Void)
-      apply_void
-    else
-      apply
-  }
-
-  public GetTupledMethodWithReturnType (ret_type : TypeVar) : IMethod
-  {
-    if (ret_type.Fix () is FixedType.Void)
-      apply_tupled_void
-    else
-      apply_tupled
-  }
-
-  public static Make (ty : TypeVar) : FixedType.Class
-  {
-    match (ty.Fix ().FunReturnTypeAndParms ()) {
-      | Some ((parms, ret)) =>
-        def inst = ty.Manager.InternalType.GetFunctionType (parms.Length);
-        if (ret.Fix () is FixedType.Void)
-          FixedType.Class (inst.VoidTyCon, parms)
-        else
-          FixedType.Class (inst.TyCon, parms + [ret])
-      | None => Util.ice ()
+    public Ctor : IMethod
+    {
+      get { ctor }
     }
-  }
 
-  static function_name = ["Nemerle", "Builtins", "Function"] : list [string];
-  static function_void_name = ["Nemerle", "Builtins", "FunctionVoid"] : list [string];
-  static function_from_tuple_name = ["Nemerle", "Builtins", "FunctionFromTuple"] : list [string];
-  static function_void_from_tuple_name = ["Nemerle", "Builtins", "FunctionVoidFromTuple"] : list [string];
-
-  internal this (m : ManagerClass, size : int)
-  {
-     tycon = m.NameTree.LookupInternalType (function_name, size + 1);
-     foreach (meth :> IMethod in tycon.LookupMember ("apply"))
-     {
-       if (meth.GetParameters ().Length == size)
-       {
-         assert (apply == null);
-         apply = meth
-       }
-       else
-       {
-         assert (apply_tupled == null);
-         apply_tupled = meth
-       }
-     }
-     assert (apply != null);
-     assert (size <= 1 || apply_tupled != null);
-
-     void_tycon = m.NameTree.LookupInternalType (function_void_name, size);
-     apply_void = void_tycon.LookupMember ("apply_void").Head :> IMethod;
-     apply_tupled_void = if (size > 1) void_tycon.LookupMember ("apply_void").Tail.Head :> IMethod else null;
-
-     when (size > 1) {
-       FromTupleTyCon = m.NameTree.LookupInternalType (function_from_tuple_name, size + 1);
-       FromTupleVoidTyCon = m.NameTree.LookupInternalType (function_void_from_tuple_name, size);
-       FromTupleCtor = FromTupleTyCon.LookupMember (".ctor").Head :> IMethod;
-       FromTupleVoidCtor = FromTupleVoidTyCon.LookupMember (".ctor").Head :> IMethod;
-     }
-  }
-}
-
-
-[ManagerAccess]
-public class InternalTypeClass
-{
-  public mutable Void_tc                              : TypeInfo;
-  public mutable Array_tc                             : TypeInfo;
-  public mutable Attribute_tc                         : TypeInfo;
-  public mutable Boolean_tc                           : TypeInfo;
-  public mutable Byte_tc                              : TypeInfo;
-  public mutable Char_tc                              : TypeInfo;
-  public mutable Decimal_tc                           : TypeInfo;
-  public mutable Delegate_tc                          : TypeInfo;
-  public mutable MulticastDelegate_tc                 : TypeInfo;
-  public mutable Double_tc                            : TypeInfo;
-  public mutable Enum_tc                              : TypeInfo;
-  public mutable Exception_tc                         : TypeInfo;
-  public mutable Int16_tc                             : TypeInfo;
-  public mutable Int32_tc                             : TypeInfo;
-  public mutable Int64_tc                             : TypeInfo;
-  public mutable Object_tc                            : TypeInfo;
-  public mutable SByte_tc                             : TypeInfo;
-  public mutable Single_tc                            : TypeInfo;
-  public mutable String_tc                            : TypeInfo;
-  public mutable Type_tc                              : TypeInfo;
-  public mutable MethodInfo_tc                        : TypeInfo;
-  public mutable ConstructorInfo_tc                   : TypeInfo;
-  public mutable FieldInfo_tc                         : TypeInfo;
-  public mutable PropertyInfo_tc                      : TypeInfo;
-  public mutable UInt16_tc                            : TypeInfo;
-  public mutable UInt32_tc                            : TypeInfo;
-  public mutable UInt64_tc                            : TypeInfo;
-  public mutable ValueType_tc                         : TypeInfo;
-  public mutable MatchFailureException_tc             : TypeInfo;
-  public mutable NullMatchException_tc                : TypeInfo;
-  public mutable ContainsMacroAttribute_tc            : TypeInfo;
-  public mutable VariantAttribute_tc                  : TypeInfo;
-  public mutable ImmutableAttribute_tc                : TypeInfo;
-  public mutable ExtensionAttribute_tc                : TypeInfo;
-  public mutable TypeAliasAttribute_tc                : TypeInfo;
-  public mutable VariantOptionAttribute_tc            : TypeInfo;
-  public mutable VolatileModifier_tc                  : TypeInfo;
-  public mutable ConstantVariantOptionAttribute_tc    : TypeInfo;
-  public mutable ExtensionPatternEncodingAttribute_tc : TypeInfo;
-  public mutable FlagsAttribute_tc                    : TypeInfo;
-  public mutable ParamArrayAttribute_tc               : TypeInfo;
-  public mutable AssemblyVersionAttribute_tc          : TypeInfo;
-  public mutable AssemblyKeyFileAttribute_tc          : TypeInfo;
-  public mutable AssemblyCultureAttribute_tc          : TypeInfo;
-  public mutable Nemerle_list_tc                      : TypeInfo;
-  public mutable Nemerle_option_tc                    : TypeInfo;
-  public mutable IList_tc                             : TypeInfo;
-  public mutable ICollection_tc                       : TypeInfo;
-  public mutable IEnumerable_tc                       : TypeInfo;
-  public mutable IEnumerator_tc                       : TypeInfo;
-  public mutable Generic_IEnumerable_tc               : TypeInfo;
-  public mutable Generic_IEnumerator_tc               : TypeInfo;
-  public mutable Generic_IList_tc                     : TypeInfo;
-  public mutable Generic_ICollection_tc               : TypeInfo;
-  public mutable Generic_Nullable_tc                  : TypeInfo;
-  public mutable DllImport_tc                         : TypeInfo;
-  public mutable Serializable_tc                      : TypeInfo;
-  public mutable Obsolete_tc                          : TypeInfo;
-  public mutable Conditional_tc                       : TypeInfo;
-  public mutable IgnoreFieldAttribute_tc              : TypeInfo;
-  public mutable IgnoreConstructorAttribute_tc        : TypeInfo;
-  public mutable IdentityFunction_tc                  : TypeInfo;
-
-  mutable function_types                              : array [FunctionType];
-  mutable tuple_types                                 : array [TupleType];
-  mutable array_types                                 : array [TypeInfo];
-
-  public mutable Void                                 : FixedType.Void;
-  public mutable Array                                : FixedType.Class;
-  public mutable Attribute                            : FixedType.Class;
-  public mutable Boolean                              : FixedType.Class;
-  public mutable Byte                                 : FixedType.Class;
-  public mutable Char                                 : FixedType.Class;
-  public mutable Decimal                              : FixedType.Class;
-  public mutable Delegate                             : FixedType.Class;
-  public mutable Double                               : FixedType.Class;
-  public mutable Enum                                 : FixedType.Class;
-  public mutable Exception                            : FixedType.Class;
-  public mutable Int16                                : FixedType.Class;
-  public mutable Int32                                : FixedType.Class;
-  public mutable Int64                                : FixedType.Class;
-  public mutable Object                               : FixedType.Class;
-  public mutable SByte                                : FixedType.Class;
-  public mutable Single                               : FixedType.Class;
-  public mutable String                               : FixedType.Class;
-  public mutable Type                                 : FixedType.Class;
-  public mutable MethodInfo                           : FixedType.Class;
-  public mutable ConstructorInfo                      : FixedType.Class;
-  public mutable FieldInfo                            : FixedType.Class;
-  public mutable PropertyInfo                         : FixedType.Class;
-  public mutable UInt16                               : FixedType.Class;
-  public mutable UInt32                               : FixedType.Class;
-  public mutable UInt64                               : FixedType.Class;
-  public mutable ValueType                            : FixedType.Class;
-  public mutable MatchFailureException                : FixedType.Class;
-  public mutable IObjectReference                     : FixedType.Class;
-  public mutable Reflection_Missing                   : FixedType.Class;
-
-  public mutable Delegate_Combine                     : IMethod;
-  public mutable Delegate_Remove                      : IMethod;
-  public mutable String_Concat                        : IMethod;
-
-  public IntegralTypes : array [FixedType.Class]
-  {
-    //[Nemerle.Memoize (InvalidValue = null)]
-    get {
-      array [InternalType.Int32, InternalType.SByte, InternalType.Byte,
-             InternalType.Int16, InternalType.UInt16, InternalType.UInt32,
-             InternalType.Int64, InternalType.UInt64]
+    public TyCon : TypeInfo
+    {
+      get { tycon }
     }
-  }
 
-  public NewMatchFailureException_ctor : IMethod
-  {
-    //[Nemerle.Memoize (InvalidValue = null)]
-    get {
-      get_single_method (MatchFailureException_tc, ".ctor");
-    }
-  }
-
-  public MatchFailureException_ctor : SR.ConstructorInfo
-  {
-    get { NewMatchFailureException_ctor.GetConstructorInfo () }
-  }
-
-  public String_opEquality : IMethod
-  {
-    //[Nemerle.Memoize (InvalidValue = null)]
-    get {
-      get_single_method (String_tc, "op_Equality");
-    }
-  }
-
-  public Decimal_opEquality : IMethod
-  {
-    //[Nemerle.Memoize (InvalidValue = null)]
-    get {
-      get_single_method (Decimal_tc, "op_Equality");
-    }
-  }
-
-  static get_single_method (tc : TypeInfo, name : string) : IMethod
-  {
-    match (tc.LookupMember (name)) {
-      | [x] => x :> IMethod
-      | _ => Util.ice ()
-    }
-  }
-
-  public GetFunctionType (len : int) : FunctionType
-  {
-    when (function_types.Length <= len)
-      Message.FatalError ($ "function types only up to $(function_types.Length - 1) "
-                            "parameters are supported, sorry (got $len)");
-    when (function_types [len] == null)
-      function_types [len] = FunctionType (Manager, len);
-
-    function_types [len]
-  }
-
-  public GetTupleType (len : int) : TupleType
-  {
-    when (tuple_types.Length <= len)
-      Message.FatalError ($ "tuple types only up to $(tuple_types.Length - 1) "
-                            "parameters are supported, sorry (got $len)");
-    when (tuple_types [len] == null)
-      tuple_types [len] = TupleType (Manager, len);
-
-    tuple_types [len]
-  }
-
-  public GetArrayType (dims : int) : TypeInfo
-  {
-    when (array_types [dims] == null)
-      array_types [dims] = lookup ($ "Nemerle.Builtins.Array$dims");
-    array_types [dims]
-  }
-
-  lookup (type_name : string) : TypeInfo
-  {
-    Manager.Lookup (type_name)
-  }
-
-  lookup (type_name : string, args_count : int) : TypeInfo
-  {
-    Manager.Lookup (type_name, args_count)
-  }
-
-  internal InitSystemTypes () : void
-  {
-    // ordering is important here
-    Boolean_tc = lookup ("System.Boolean"); Boolean = FixedType.Class (Boolean_tc, []);
-    Int32_tc = lookup ("System.Int32"); Int32 = FixedType.Class (Int32_tc, []);
-
-    Manager.LibrariesManager.add_buildins = true;
-    (Boolean_tc :> LibraryReference.ExternalTypeInfo).AddBuiltins ();
-    (Int32_tc :> LibraryReference.ExternalTypeInfo).AddBuiltins ();
-
-    // and here not
-    Object_tc = lookup ("System.Object"); Object = FixedType.Class (Object_tc, []);
-    (Object_tc :> LibraryReference.ExternalTypeInfo).AddBuiltins ();
-    Void_tc = lookup ("System.Void"); Void = FixedType.Void();
-    Array_tc = lookup ("System.Array"); Array = FixedType.Class (Array_tc, []);
-    Attribute_tc = lookup ("System.Attribute"); Attribute = FixedType.Class (Attribute_tc, []);
-    Byte_tc = lookup ("System.Byte"); Byte = FixedType.Class (Byte_tc, []);
-    Char_tc = lookup ("System.Char"); Char = FixedType.Class (Char_tc, []);
-    Decimal_tc = lookup ("System.Decimal"); Decimal = FixedType.Class (Decimal_tc, []);
-    Delegate_tc = lookup ("System.Delegate"); Delegate = FixedType.Class (Delegate_tc, []);
-    MulticastDelegate_tc = lookup ("System.MulticastDelegate");
-    Double_tc = lookup ("System.Double"); Double = FixedType.Class (Double_tc, []);
-    Enum_tc = lookup ("System.Enum"); Enum = FixedType.Class (Enum_tc, []);
-    Exception_tc = lookup ("System.Exception"); Exception = FixedType.Class (Exception_tc, []);
-    Int16_tc = lookup ("System.Int16"); Int16 = FixedType.Class (Int16_tc, []);
-    Int64_tc = lookup ("System.Int64"); Int64 = FixedType.Class (Int64_tc, []);
-    SByte_tc = lookup ("System.SByte"); SByte = FixedType.Class (SByte_tc, []);
-    Single_tc = lookup ("System.Single"); Single = FixedType.Class (Single_tc, []);
-    String_tc = lookup ("System.String"); String = FixedType.Class (String_tc, []);
-    Type_tc = lookup ("System.Type"); InternalType.Type = FixedType.Class (Type_tc, []);
-    MethodInfo_tc = lookup ("System.Reflection.MethodInfo"); InternalType.MethodInfo = FixedType.Class (MethodInfo_tc, []);
-    ConstructorInfo_tc = lookup ("System.Reflection.ConstructorInfo"); InternalType.ConstructorInfo = FixedType.Class (ConstructorInfo_tc, []);
-    FieldInfo_tc = lookup ("System.Reflection.FieldInfo"); InternalType.FieldInfo = FixedType.Class (FieldInfo_tc, []);
-    PropertyInfo_tc = lookup ("System.Reflection.PropertyInfo"); InternalType.PropertyInfo = FixedType.Class (PropertyInfo_tc, []);
-    UInt16_tc = lookup ("System.UInt16"); UInt16 = FixedType.Class (UInt16_tc, []);
-    UInt32_tc = lookup ("System.UInt32"); UInt32 = FixedType.Class (UInt32_tc, []);
-    UInt64_tc = lookup ("System.UInt64"); UInt64 = FixedType.Class (UInt64_tc, []);
-    ValueType_tc = lookup ("System.ValueType"); ValueType = FixedType.Class (ValueType_tc, []);
-    IEnumerable_tc = lookup ("System.Collections.IEnumerable");
-    IEnumerator_tc = lookup ("System.Collections.IEnumerator");
-    IList_tc = lookup ("System.Collections.IList");
-    ICollection_tc = lookup ("System.Collections.ICollection");
-    Generic_IEnumerable_tc = lookup ("System.Collections.Generic.IEnumerable");
-    Generic_IEnumerator_tc = lookup ("System.Collections.Generic.IEnumerator");
-    Generic_IList_tc = lookup ("System.Collections.Generic.IList");
-    Generic_ICollection_tc = lookup ("System.Collections.Generic.ICollection");
-    Generic_Nullable_tc = lookup ("System.Nullable", 1);
-    DllImport_tc = lookup ("System.Runtime.InteropServices.DllImportAttribute");
-    Serializable_tc = lookup ("System.SerializableAttribute");
-    Obsolete_tc = lookup ("System.ObsoleteAttribute");
-    Conditional_tc = lookup ("System.Diagnostics.ConditionalAttribute");
-    IObjectReference = FixedType.Class (lookup ("System.Runtime.Serialization.IObjectReference"), []);
-    Reflection_Missing = FixedType.Class (lookup ("System.Reflection.Missing"), []);
-
-    ParamArrayAttribute_tc = lookup ("System.ParamArrayAttribute");
-    FlagsAttribute_tc = lookup ("System.FlagsAttribute");
-    AssemblyVersionAttribute_tc = lookup ("System.Reflection.AssemblyVersionAttribute");
-    AssemblyKeyFileAttribute_tc = lookup ("System.Reflection.AssemblyKeyFileAttribute");
-    AssemblyCultureAttribute_tc = lookup ("System.Reflection.AssemblyCultureAttribute");
-
-    def is_right (mem : IMember) {
-      match (mem) {
-        | meth is IMethod =>
-          def parms = meth.GetParameters ();
-          meth.IsStatic &&
-          parms.Length == 2 &&
-          ! parms.Head.ty.Equals (Object)
-        | _ => false
+    public static Make (ty : TypeVar) : FixedType.Class
+    {
+      match (ty.Fix ()) {
+        | Tuple (types) =>
+            def inst = ty.Manager.InternalType.GetTupleType (types.Length);
+            FixedType.Class (inst.tycon, types)
+        | _ => Util.ice ()
       }
     }
 
-    def single (tc : TypeInfo, name)
+    get_field (pos : int) : IField
     {
-      match (tc.LookupMember(name).Filter(is_right))
-      {
-        | [s] => s :> IMethod
+      match (tycon.LookupMember (sprintf ("Field%d", pos - 1))) {
+        | [x] => x :> IField
         | _ => assert (false)
       }
     }
 
-    Delegate_Combine = single (Delegate_tc, "Combine");
-    Delegate_Remove = single (Delegate_tc, "Remove");
-    String_Concat = single (String_tc, "Concat");
+    static name = ["Nemerle", "Builtins", "Tuple"] : list [string];
 
-    function_types = array (21);
-    tuple_types = array (21);
-    array_types = array (20);
+    public static IsTupleMember (ty : IMember) : bool
+    {
+      def dt = ty.DeclaringType;
+      def typarmsCount = dt.TyparmsCount;
+      typarmsCount > 1 && dt.Equals (dt.Manager.InternalType.GetTupleType (typarmsCount).tycon)
+    }
 
-    InternalType.MatchFailureException_tc = null; // cleanup
-  }
-
-  // to be called after scan_globals (think about compiling nemerle.dll)
-  internal InitNemerleTypes () : void
-  {
-    // prevent multiple execution
-    when (InternalType.MatchFailureException_tc == null) {
-      SystemTypeCache.NemerleAttribute = SystemTypeCache.Reflect ("Nemerle.Internal.NemerleAttribute");
-      InternalType.MatchFailureException_tc = lookup ("Nemerle.Core.MatchFailureException");
-      InternalType.MatchFailureException = FixedType.Class (InternalType.MatchFailureException_tc, []);
-
-      InternalType.NullMatchException_tc = lookup ("Nemerle.Core.NullMatchException");
-      InternalType.ContainsMacroAttribute_tc = lookup ("Nemerle.Internal.ContainsMacroAttribute");
-      InternalType.VariantAttribute_tc = lookup ("Nemerle.Internal.VariantAttribute");
-      InternalType.TypeAliasAttribute_tc = lookup ("Nemerle.Internal.TypeAliasAttribute");
-      InternalType.VariantOptionAttribute_tc = lookup ("Nemerle.Internal.VariantOptionAttribute");
-      InternalType.VolatileModifier_tc = lookup ("Nemerle.Internal.VolatileModifier");
-      InternalType.ImmutableAttribute_tc = lookup ("Nemerle.Internal.ImmutableAttribute");
-      InternalType.ExtensionAttribute_tc = lookup ("Nemerle.Internal.ExtensionAttribute");
-      InternalType.ConstantVariantOptionAttribute_tc = lookup ("Nemerle.Internal.ConstantVariantOptionAttribute");
-      InternalType.ExtensionPatternEncodingAttribute_tc = lookup ("Nemerle.Internal.ExtensionPatternEncodingAttribute");
-
-      InternalType.Nemerle_list_tc = lookup ("Nemerle.Core.list", 1);
-      InternalType.Nemerle_option_tc = lookup ("Nemerle.Core.option");
-
-      InternalType.IgnoreFieldAttribute_tc = lookup ("Nemerle.Internal.IgnoreFieldAttribute");
-      InternalType.IgnoreConstructorAttribute_tc = lookup ("Nemerle.Internal.IgnoreConstructorAttribute");
-
-      InternalType.IdentityFunction_tc = lookup("Nemerle.Utility.Identity");
+    internal this (m : ManagerClass, size : int)
+    {
+      tycon = m.NameTree.LookupInternalType (name, size);
+      fields = array (size + 1);
+      for (mutable i = 1; i <= size; ++i)
+        fields [i] = get_field (i);
+      ctor = tycon.LookupMember (".ctor").Head :> IMethod;
     }
   }
 
-  internal this (man : ManagerClass)
-  {
-    Manager = man;
+  public class FunctionType {
+    internal tycon : TypeInfo;
+    internal void_tycon : TypeInfo;
+    internal apply : IMethod;
+    internal apply_void : IMethod;
+    internal apply_tupled : IMethod;
+    internal apply_tupled_void : IMethod;
+
+    public ApplyMethod : IMethod
+    {
+      get { apply }
+    }
+
+    public ApplyVoidMethod : IMethod
+    {
+      get { apply_void }
+    }
+
+    public TyCon : TypeInfo
+    {
+      get { tycon }
+    }
+
+    public VoidTyCon : TypeInfo
+    {
+      get { void_tycon }
+    }
+
+    public FromTupleTyCon : TypeInfo;
+    public FromTupleVoidTyCon : TypeInfo;
+    public FromTupleCtor : IMethod;
+    public FromTupleVoidCtor : IMethod;
+
+    public GetMethodWithReturnType (ret_type : TypeVar) : IMethod
+    {
+      if (ret_type.Fix () is FixedType.Void)
+        apply_void
+      else
+        apply
+    }
+
+    public GetTupledMethodWithReturnType (ret_type : TypeVar) : IMethod
+    {
+      if (ret_type.Fix () is FixedType.Void)
+        apply_tupled_void
+      else
+        apply_tupled
+    }
+
+    public static Make (ty : TypeVar) : FixedType.Class
+    {
+      match (ty.Fix ().FunReturnTypeAndParms ()) {
+        | Some ((parms, ret)) =>
+            def inst = ty.Manager.InternalType.GetFunctionType (parms.Length);
+            if (ret.Fix () is FixedType.Void)
+              FixedType.Class (inst.VoidTyCon, parms)
+            else
+              FixedType.Class (inst.TyCon, parms + [ret])
+        | None => Util.ice ()
+      }
+    }
+
+    static function_name = ["Nemerle", "Builtins", "Function"] : list [string];
+    static function_void_name = ["Nemerle", "Builtins", "FunctionVoid"] : list [string];
+    static function_from_tuple_name = ["Nemerle", "Builtins", "FunctionFromTuple"] : list [string];
+    static function_void_from_tuple_name = ["Nemerle", "Builtins", "FunctionVoidFromTuple"] : list [string];
+
+    internal this (m : ManagerClass, size : int)
+    {
+      tycon = m.NameTree.LookupInternalType (function_name, size + 1);
+      foreach (meth :> IMethod in tycon.LookupMember ("apply"))
+      {
+        if (meth.GetParameters ().Length == size)
+        {
+          assert (apply == null);
+          apply = meth
+        }
+        else
+        {
+          assert (apply_tupled == null);
+          apply_tupled = meth
+        }
+      }
+      assert (apply != null);
+      assert (size <= 1 || apply_tupled != null);
+
+      void_tycon = m.NameTree.LookupInternalType (function_void_name, size);
+      apply_void = void_tycon.LookupMember ("apply_void").Head :> IMethod;
+      apply_tupled_void = if (size > 1) void_tycon.LookupMember ("apply_void").Tail.Head :> IMethod else null;
+
+      when (size > 1) {
+        FromTupleTyCon = m.NameTree.LookupInternalType (function_from_tuple_name, size + 1);
+        FromTupleVoidTyCon = m.NameTree.LookupInternalType (function_void_from_tuple_name, size);
+        FromTupleCtor = FromTupleTyCon.LookupMember (".ctor").Head :> IMethod;
+        FromTupleVoidCtor = FromTupleVoidTyCon.LookupMember (".ctor").Head :> IMethod;
+      }
+    }
   }
-}
+
+
+  [ManagerAccess]
+  public class InternalTypeClass
+  {
+    public mutable Void_tc                              : TypeInfo;
+    public mutable Array_tc                             : TypeInfo;
+    public mutable Attribute_tc                         : TypeInfo;
+    public mutable Boolean_tc                           : TypeInfo;
+    public mutable Byte_tc                              : TypeInfo;
+    public mutable Char_tc                              : TypeInfo;
+    public mutable Decimal_tc                           : TypeInfo;
+    public mutable Delegate_tc                          : TypeInfo;
+    public mutable MulticastDelegate_tc                 : TypeInfo;
+    public mutable Double_tc                            : TypeInfo;
+    public mutable Enum_tc                              : TypeInfo;
+    public mutable Exception_tc                         : TypeInfo;
+    public mutable Int16_tc                             : TypeInfo;
+    public mutable Int32_tc                             : TypeInfo;
+    public mutable Int64_tc                             : TypeInfo;
+    public mutable Object_tc                            : TypeInfo;
+    public mutable SByte_tc                             : TypeInfo;
+    public mutable Single_tc                            : TypeInfo;
+    public mutable String_tc                            : TypeInfo;
+    public mutable Type_tc                              : TypeInfo;
+    public mutable MethodInfo_tc                        : TypeInfo;
+    public mutable ConstructorInfo_tc                   : TypeInfo;
+    public mutable FieldInfo_tc                         : TypeInfo;
+    public mutable PropertyInfo_tc                      : TypeInfo;
+    public mutable UInt16_tc                            : TypeInfo;
+    public mutable UInt32_tc                            : TypeInfo;
+    public mutable UInt64_tc                            : TypeInfo;
+    public mutable ValueType_tc                         : TypeInfo;
+    public mutable MatchFailureException_tc             : TypeInfo;
+    public mutable NullMatchException_tc                : TypeInfo;
+    public mutable ContainsMacroAttribute_tc            : TypeInfo;
+    public mutable VariantAttribute_tc                  : TypeInfo;
+    public mutable ImmutableAttribute_tc                : TypeInfo;
+    public mutable ExtensionAttribute_tc                : TypeInfo;
+    public mutable TypeAliasAttribute_tc                : TypeInfo;
+    public mutable VariantOptionAttribute_tc            : TypeInfo;
+    public mutable VolatileModifier_tc                  : TypeInfo;
+    public mutable ConstantVariantOptionAttribute_tc    : TypeInfo;
+    public mutable ExtensionPatternEncodingAttribute_tc : TypeInfo;
+    public mutable FlagsAttribute_tc                    : TypeInfo;
+    public mutable ParamArrayAttribute_tc               : TypeInfo;
+    public mutable AssemblyVersionAttribute_tc          : TypeInfo;
+    public mutable AssemblyKeyFileAttribute_tc         : TypeInfo;
+    public mutable AssemblyCompanyAttribute_tc          : TypeInfo;
+    public mutable AssemblyProductAttribute_tc          : TypeInfo;
+    public mutable AssemblyTitleAttribute_tc            : TypeInfo;
+    public mutable AssemblyDescriptionAttribute_tc      : TypeInfo;
+    public mutable AssemblyCopyrightAttribute_tc        : TypeInfo;
+    public mutable AssemblyCultureAttribute_tc          : TypeInfo;
+    public mutable AssemblyFileVersionAttribute_tc      : TypeInfo;
+    public mutable Nemerle_list_tc                      : TypeInfo;
+    public mutable Nemerle_option_tc                    : TypeInfo;
+    public mutable IList_tc                             : TypeInfo;
+    public mutable ICollection_tc                       : TypeInfo;
+    public mutable IEnumerable_tc                       : TypeInfo;
+    public mutable IEnumerator_tc                       : TypeInfo;
+    public mutable Generic_IEnumerable_tc               : TypeInfo;
+    public mutable Generic_IEnumerator_tc               : TypeInfo;
+    public mutable Generic_IList_tc                     : TypeInfo;
+    public mutable Generic_ICollection_tc               : TypeInfo;
+    public mutable Generic_Nullable_tc                  : TypeInfo;
+    public mutable DllImport_tc                         : TypeInfo;
+    public mutable Serializable_tc                      : TypeInfo;
+    public mutable Obsolete_tc                          : TypeInfo;
+    public mutable Conditional_tc                       : TypeInfo;
+    public mutable IgnoreFieldAttribute_tc              : TypeInfo;
+    public mutable IgnoreConstructorAttribute_tc        : TypeInfo;
+    public mutable IdentityFunction_tc                  : TypeInfo;
+
+    mutable function_types                              : array [FunctionType];
+    mutable tuple_types                                 : array [TupleType];
+    mutable array_types                                 : array [TypeInfo];
+
+    public mutable Void                                 : FixedType.Void;
+    public mutable Array                                : FixedType.Class;
+    public mutable Attribute                            : FixedType.Class;
+    public mutable Boolean                              : FixedType.Class;
+    public mutable Byte                                 : FixedType.Class;
+    public mutable Char                                 : FixedType.Class;
+    public mutable Decimal                              : FixedType.Class;
+    public mutable Delegate                             : FixedType.Class;
+    public mutable Double                               : FixedType.Class;
+    public mutable Enum                                 : FixedType.Class;
+    public mutable Exception                            : FixedType.Class;
+    public mutable Int16                                : FixedType.Class;
+    public mutable Int32                                : FixedType.Class;
+    public mutable Int64                                : FixedType.Class;
+    public mutable Object                               : FixedType.Class;
+    public mutable SByte                                : FixedType.Class;
+    public mutable Single                               : FixedType.Class;
+    public mutable String                               : FixedType.Class;
+    public mutable Type                                 : FixedType.Class;
+    public mutable MethodInfo                           : FixedType.Class;
+    public mutable ConstructorInfo                      : FixedType.Class;
+    public mutable FieldInfo                            : FixedType.Class;
+    public mutable PropertyInfo                         : FixedType.Class;
+    public mutable UInt16                               : FixedType.Class;
+    public mutable UInt32                               : FixedType.Class;
+    public mutable UInt64                               : FixedType.Class;
+    public mutable ValueType                            : FixedType.Class;
+    public mutable MatchFailureException                : FixedType.Class;
+    public mutable IObjectReference                     : FixedType.Class;
+    public mutable Reflection_Missing                   : FixedType.Class;
+
+    public mutable Delegate_Combine                     : IMethod;
+    public mutable Delegate_Remove                      : IMethod;
+    public mutable String_Concat                        : IMethod;
+
+    public IntegralTypes : array [FixedType.Class]
+    {
+    //[Nemerle.Memoize (InvalidValue = null)]
+      get {
+      array [InternalType.Int32, InternalType.SByte, InternalType.Byte,
+            InternalType.Int16, InternalType.UInt16, InternalType.UInt32,
+            InternalType.Int64, InternalType.UInt64]
+      }
+    }
+
+    public NewMatchFailureException_ctor : IMethod
+    {
+    //[Nemerle.Memoize (InvalidValue = null)]
+      get {
+        get_single_method (MatchFailureException_tc, ".ctor");
+      }
+    }
+
+    public MatchFailureException_ctor : SR.ConstructorInfo
+    {
+      get { NewMatchFailureException_ctor.GetConstructorInfo () }
+    }
+
+    public String_opEquality : IMethod
+    {
+    //[Nemerle.Memoize (InvalidValue = null)]
+      get {
+        get_single_method (String_tc, "op_Equality");
+      }
+    }
+
+    public Decimal_opEquality : IMethod
+    {
+    //[Nemerle.Memoize (InvalidValue = null)]
+      get {
+        get_single_method (Decimal_tc, "op_Equality");
+      }
+    }
+
+    static get_single_method (tc : TypeInfo, name : string) : IMethod
+    {
+      match (tc.LookupMember (name)) {
+        | [x] => x :> IMethod
+        | _ => Util.ice ()
+      }
+    }
+
+    public GetFunctionType (len : int) : FunctionType
+    {
+      when (function_types.Length <= len)
+        Message.FatalError ($ "function types only up to $(function_types.Length - 1) "
+                            "parameters are supported, sorry (got $len)");
+      when (function_types [len] == null)
+        function_types [len] = FunctionType (Manager, len);
+
+      function_types [len]
+    }
+
+    public GetTupleType (len : int) : TupleType
+    {
+      when (tuple_types.Length <= len)
+        Message.FatalError ($ "tuple types only up to $(tuple_types.Length - 1) "
+                            "parameters are supported, sorry (got $len)");
+      when (tuple_types [len] == null)
+        tuple_types [len] = TupleType (Manager, len);
+
+      tuple_types [len]
+    }
+
+    public GetArrayType (dims : int) : TypeInfo
+    {
+      when (array_types [dims] == null)
+        array_types [dims] = lookup ($ "Nemerle.Builtins.Array$dims");
+      array_types [dims]
+    }
+
+    lookup (type_name : string) : TypeInfo
+    {
+      Manager.Lookup (type_name)
+    }
+
+    lookup (type_name : string, args_count : int) : TypeInfo
+    {
+      Manager.Lookup (type_name, args_count)
+    }
+
+    internal InitSystemTypes () : void
+    {
+    // ordering is important here
+      Boolean_tc = lookup ("System.Boolean"); Boolean = FixedType.Class (Boolean_tc, []);
+      Int32_tc = lookup ("System.Int32"); Int32 = FixedType.Class (Int32_tc, []);
+
+      Manager.LibrariesManager.add_buildins = true;
+    (Boolean_tc :> LibraryReference.ExternalTypeInfo).AddBuiltins ();
+    (Int32_tc :> LibraryReference.ExternalTypeInfo).AddBuiltins ();
+
+    // and here not
+      Object_tc = lookup ("System.Object"); Object = FixedType.Class (Object_tc, []);
+    (Object_tc :> LibraryReference.ExternalTypeInfo).AddBuiltins ();
+      Void_tc = lookup ("System.Void"); Void = FixedType.Void();
+      Array_tc = lookup ("System.Array"); Array = FixedType.Class (Array_tc, []);
+      Attribute_tc = lookup ("System.Attribute"); Attribute = FixedType.Class (Attribute_tc, []);
+      Byte_tc = lookup ("System.Byte"); Byte = FixedType.Class (Byte_tc, []);
+      Char_tc = lookup ("System.Char"); Char = FixedType.Class (Char_tc, []);
+      Decimal_tc = lookup ("System.Decimal"); Decimal = FixedType.Class (Decimal_tc, []);
+      Delegate_tc = lookup ("System.Delegate"); Delegate = FixedType.Class (Delegate_tc, []);
+      MulticastDelegate_tc = lookup ("System.MulticastDelegate");
+      Double_tc = lookup ("System.Double"); Double = FixedType.Class (Double_tc, []);
+      Enum_tc = lookup ("System.Enum"); Enum = FixedType.Class (Enum_tc, []);
+      Exception_tc = lookup ("System.Exception"); Exception = FixedType.Class (Exception_tc, []);
+      Int16_tc = lookup ("System.Int16"); Int16 = FixedType.Class (Int16_tc, []);
+      Int64_tc = lookup ("System.Int64"); Int64 = FixedType.Class (Int64_tc, []);
+      SByte_tc = lookup ("System.SByte"); SByte = FixedType.Class (SByte_tc, []);
+      Single_tc = lookup ("System.Single"); Single = FixedType.Class (Single_tc, []);
+      String_tc = lookup ("System.String"); String = FixedType.Class (String_tc, []);
+      Type_tc = lookup ("System.Type"); InternalType.Type = FixedType.Class (Type_tc, []);
+      MethodInfo_tc = lookup ("System.Reflection.MethodInfo"); InternalType.MethodInfo = FixedType.Class (MethodInfo_tc, []);
+      ConstructorInfo_tc = lookup ("System.Reflection.ConstructorInfo"); InternalType.ConstructorInfo = FixedType.Class (ConstructorInfo_tc, []);
+      FieldInfo_tc = lookup ("System.Reflection.FieldInfo"); InternalType.FieldInfo = FixedType.Class (FieldInfo_tc, []);
+      PropertyInfo_tc = lookup ("System.Reflection.PropertyInfo"); InternalType.PropertyInfo = FixedType.Class (PropertyInfo_tc, []);
+      UInt16_tc = lookup ("System.UInt16"); UInt16 = FixedType.Class (UInt16_tc, []);
+      UInt32_tc = lookup ("System.UInt32"); UInt32 = FixedType.Class (UInt32_tc, []);
+      UInt64_tc = lookup ("System.UInt64"); UInt64 = FixedType.Class (UInt64_tc, []);
+      ValueType_tc = lookup ("System.ValueType"); ValueType = FixedType.Class (ValueType_tc, []);
+      IEnumerable_tc = lookup ("System.Collections.IEnumerable");
+      IEnumerator_tc = lookup ("System.Collections.IEnumerator");
+      IList_tc = lookup ("System.Collections.IList");
+      ICollection_tc = lookup ("System.Collections.ICollection");
+      Generic_IEnumerable_tc = lookup ("System.Collections.Generic.IEnumerable");
+      Generic_IEnumerator_tc = lookup ("System.Collections.Generic.IEnumerator");
+      Generic_IList_tc = lookup ("System.Collections.Generic.IList");
+      Generic_ICollection_tc = lookup ("System.Collections.Generic.ICollection");
+      Generic_Nullable_tc = lookup ("System.Nullable", 1);
+      DllImport_tc = lookup ("System.Runtime.InteropServices.DllImportAttribute");
+      Serializable_tc = lookup ("System.SerializableAttribute");
+      Obsolete_tc = lookup ("System.ObsoleteAttribute");
+      Conditional_tc = lookup ("System.Diagnostics.ConditionalAttribute");
+      IObjectReference = FixedType.Class (lookup ("System.Runtime.Serialization.IObjectReference"), []);
+      Reflection_Missing = FixedType.Class (lookup ("System.Reflection.Missing"), []);
+
+      ParamArrayAttribute_tc = lookup ("System.ParamArrayAttribute");
+      FlagsAttribute_tc = lookup ("System.FlagsAttribute");
+      AssemblyVersionAttribute_tc = lookup ("System.Reflection.AssemblyVersionAttribute");
+      AssemblyKeyFileAttribute_tc = lookup ("System.Reflection.AssemblyKeyFileAttribute");
+      AssemblyCultureAttribute_tc = lookup ("System.Reflection.AssemblyCultureAttribute");
+      AssemblyCompanyAttribute_tc = lookup ("System.Reflection.AssemblyCompanyAttribute");
+      AssemblyCopyrightAttribute_tc = lookup ("System.Reflection.AssemblyCopyrightAttribute");
+      AssemblyDescriptionAttribute_tc = lookup ("System.Reflection.AssemblyDescriptionAttribute");
+      AssemblyFileVersionAttribute_tc = lookup ("System.Reflection.AssemblyFileVersionAttribute");
+      AssemblyTitleAttribute_tc = lookup ("System.Reflection.AssemblyTitleAttribute");
+      AssemblyProductAttribute_tc = lookup ("System.Reflection.AssemblyProductAttribute");
+
+
+      def is_right (mem : IMember) {
+        match (mem) {
+          | meth is IMethod =>
+              def parms = meth.GetParameters ();
+          meth.IsStatic &&
+          parms.Length == 2 &&
+          ! parms.Head.ty.Equals (Object)
+          | _ => false
+        }
+      }
+
+      def single (tc : TypeInfo, name)
+      {
+        match (tc.LookupMember(name).Filter(is_right))
+        {
+          | [s] => s :> IMethod
+          | _ => assert (false)
+        }
+      }
+
+      Delegate_Combine = single (Delegate_tc, "Combine");
+      Delegate_Remove = single (Delegate_tc, "Remove");
+      String_Concat = single (String_tc, "Concat");
+
+      function_types = array (21);
+      tuple_types = array (21);
+      array_types = array (20);
+
+      InternalType.MatchFailureException_tc = null; // cleanup
+    }
+
+  // to be called after scan_globals (think about compiling nemerle.dll)
+    internal InitNemerleTypes () : void
+    {
+    // prevent multiple execution
+      when (InternalType.MatchFailureException_tc == null) {
+        SystemTypeCache.NemerleAttribute = SystemTypeCache.Reflect ("Nemerle.Internal.NemerleAttribute");
+        InternalType.MatchFailureException_tc = lookup ("Nemerle.Core.MatchFailureException");
+        InternalType.MatchFailureException = FixedType.Class (InternalType.MatchFailureException_tc, []);
+
+        InternalType.NullMatchException_tc = lookup ("Nemerle.Core.NullMatchException");
+        InternalType.ContainsMacroAttribute_tc = lookup ("Nemerle.Internal.ContainsMacroAttribute");
+        InternalType.VariantAttribute_tc = lookup ("Nemerle.Internal.VariantAttribute");
+        InternalType.TypeAliasAttribute_tc = lookup ("Nemerle.Internal.TypeAliasAttribute");
+        InternalType.VariantOptionAttribute_tc = lookup ("Nemerle.Internal.VariantOptionAttribute");
+        InternalType.VolatileModifier_tc = lookup ("Nemerle.Internal.VolatileModifier");
+        InternalType.ImmutableAttribute_tc = lookup ("Nemerle.Internal.ImmutableAttribute");
+        InternalType.ExtensionAttribute_tc = lookup ("Nemerle.Internal.ExtensionAttribute");
+        InternalType.ConstantVariantOptionAttribute_tc = lookup ("Nemerle.Internal.ConstantVariantOptionAttribute");
+        InternalType.ExtensionPatternEncodingAttribute_tc = lookup ("Nemerle.Internal.ExtensionPatternEncodingAttribute");
+
+        InternalType.Nemerle_list_tc = lookup ("Nemerle.Core.list", 1);
+        InternalType.Nemerle_option_tc = lookup ("Nemerle.Core.option");
+
+        InternalType.IgnoreFieldAttribute_tc = lookup ("Nemerle.Internal.IgnoreFieldAttribute");
+        InternalType.IgnoreConstructorAttribute_tc = lookup ("Nemerle.Internal.IgnoreConstructorAttribute");
+
+        InternalType.IdentityFunction_tc = lookup("Nemerle.Utility.Identity");
+      }
+    }
+
+    internal this (man : ManagerClass)
+    {
+      Manager = man;
+    }
+  }
 
 } // end ns

--- a/ncc/generation/HierarchyEmitter.n
+++ b/ncc/generation/HierarchyEmitter.n
@@ -219,10 +219,10 @@ namespace Nemerle.Compiler
           | e is System.ArgumentException =>
             Message.Error($"Could not embed unmanaged resource $uresource: $(e.Message)");
         }
-	   }
-	 else
-	 {
-	   this._assembly_builder.DefineVersionInfoResource();  
+     }
+   else
+   {
+     this._assembly_builder.DefineVersionInfoResource();  
      }
 
     }

--- a/ncc/generation/HierarchyEmitter.n
+++ b/ncc/generation/HierarchyEmitter.n
@@ -118,6 +118,7 @@ namespace Nemerle.Compiler
            assembly_requirements,
            dir, required, optional, refused);
 
+      GetInformationalAssemblyAttributes().Iter(this._assembly_builder.SetCustomAttribute);
 #pragma warning restore 618
 
       when (_assembly_name.Name == "") Message.FatalError ("name of output assembly cannot be empty");
@@ -131,7 +132,7 @@ namespace Nemerle.Compiler
           this._assembly_builder.DefineDynamicModule (_assembly_name.Name,
                                                       Path.GetFileName (_OutputFileName),
                                                       Manager.Options.EmitDebug);
-
+    
       when (Manager.Options.EmitDebug) _debug_emit = _module_builder.GetSymWriter ();
     }
 
@@ -208,7 +209,7 @@ namespace Nemerle.Compiler
       }
 
       def uresource = Manager.Options.UnmanagedResource;
-      when(uresource != null) {
+      if(uresource != null) {
         try {
           _module_builder.DefineUnmanagedResource(uresource);
         }
@@ -218,7 +219,11 @@ namespace Nemerle.Compiler
           | e is System.ArgumentException =>
             Message.Error($"Could not embed unmanaged resource $uresource: $(e.Message)");
         }
-      }
+	   }
+	 else
+	 {
+	   this._assembly_builder.DefineVersionInfoResource();  
+     }
 
     }
 

--- a/ncc/hierarchy/CustomAttribute.n
+++ b/ncc/hierarchy/CustomAttribute.n
@@ -34,6 +34,7 @@ using SY = System;
 
 using PT = Nemerle.Compiler.Parsetree;
 using SR = System.Reflection;
+using SRE = System.Reflection.Emit;
 using SRI = System.Runtime.InteropServices;
 using SS = System.Security;
 using SSP = System.Security.Permissions;
@@ -78,62 +79,62 @@ namespace Nemerle.Compiler
       match (expr) {
         | <[ $(_ : name) ]>
         | <[ $_x . $_y ]> =>
-          ResolveAttribute (env, <[ $expr () ]>, expect_exact)
+            ResolveAttribute (env, <[ $expr () ]>, expect_exact)
 
         | <[ $name ( .. $parms ) ]> =>
-          match (Util.QidOfExpr (name)) {
-            | Some ((id, name)) =>
-              def is_attribute (t : TypeInfo) {
-                if (expect_exact != null)
-                  t.Equals (expect_exact)
-                else
-                  t.IsDerivedFrom(InternalType.Attribute_tc)
-              }
-
-              def ctx = name.GetEnv (env);
-              def plain = ctx.LookupType (id);
-              def withattr = ctx.LookupType (add_end (id, "Attribute"));
-
-              match ((plain, withattr)) {
-                | (Some (t), None)
-                | (None, Some (t)) =>
-                  if (is_attribute (t))
-                    Some ((t, parms))
-                  else if (expect_exact == null)
-                    Message.FatalError ($"`$(t.FullName)' is not an attribute class");
-                  else None ()
-
-                | (Some (t1), Some (t2)) =>
-                  if (is_attribute (t1))
-                    if (is_attribute (t2))
-                      Message.FatalError ($"ambiguous attribute type name,"
-                                           " it could be `$(t1)' or `$(t2)'");
+            match (Util.QidOfExpr (name)) {
+              | Some ((id, name)) =>
+                  def is_attribute (t : TypeInfo) {
+                    if (expect_exact != null)
+                      t.Equals (expect_exact)
                     else
-                      Some ((t1, parms))
-                  else
-                    if (is_attribute (t2)) Some ((t2, parms))
-                    else if (expect_exact == null)
-                      Message.FatalError ($"neither `$(t1)' nor `$(t2)' is an attribute class");
-                    else None ()
+                      t.IsDerivedFrom(InternalType.Attribute_tc)
+                  }
 
-                | _ => None ()
-              }
+                  def ctx = name.GetEnv (env);
+                  def plain = ctx.LookupType (id);
+                  def withattr = ctx.LookupType (add_end (id, "Attribute"));
 
-            | _ => None ()
-          }
+                  match ((plain, withattr)) {
+                    | (Some (t), None)
+                    | (None, Some (t)) =>
+                        if (is_attribute (t))
+                          Some ((t, parms))
+                        else if (expect_exact == null)
+                               Message.FatalError ($"`$(t.FullName)' is not an attribute class");
+                             else None ()
+
+                    | (Some (t1), Some (t2)) =>
+                        if (is_attribute (t1))
+                          if (is_attribute (t2))
+                            Message.FatalError ($"ambiguous attribute type name,"
+                                                 " it could be `$(t1)' or `$(t2)'");
+                          else
+                            Some ((t1, parms))
+                        else
+                          if (is_attribute (t2)) Some ((t2, parms))
+                          else if (expect_exact == null)
+                                 Message.FatalError ($"neither `$(t1)' nor `$(t2)' is an attribute class");
+                               else None ()
+
+                    | _ => None ()
+                  }
+
+              | _ => None ()
+            }
         | _ => None ()
       }
-   }
+    }
 
     internal CheckAttribute (env : GlobalEnv, expr : PT.PExpr) : TypeInfo * list [PT.PExpr]
     {
       Util.locate (expr.Location,
-        match (ResolveAttribute(env, expr))
-        {
-          | Some ((t, parms)) => (t, parms.Map(parm => ConstantFolder.FoldConstants(env, parm)))
-          | None =>
-            Message.FatalError ($"the custom attribute `$(PrettyPrint.SprintExpr(None(), expr))' could not be found or is invalid")
-        })
+                   match (ResolveAttribute(env, expr))
+                   {
+                     | Some ((t, parms)) => (t, parms.Map(parm => ConstantFolder.FoldConstants(env, parm)))
+                     | None =>
+                         Message.FatalError ($"the custom attribute `$(PrettyPrint.SprintExpr(None(), expr))' could not be found or is invalid")
+                   })
     }
 
     internal GetCompiledAssemblyAttributes (attrs : SCG.List [GlobalEnv * PT.PExpr])
@@ -168,12 +169,12 @@ namespace Nemerle.Compiler
 
         when (is_security_attribute (tc)) {
           match (create_instance (env, tc, parms)) {
-          | ps is SSP.PermissionSetAttribute => result ::= (ps.Action, ps.CreatePermissionSet ())
-          | sa is SSP.SecurityAttribute =>
-            def perm_set = SS.PermissionSet (SSP.PermissionState.None);
-            _ = perm_set.AddPermission (sa.CreatePermission ());
-            result ::= (sa.Action, perm_set)
-          | _ => Message.FatalError (attr.Location, "given attribute must be a System.Security.Permissions.SecurityAttribute")
+            | ps is SSP.PermissionSetAttribute => result ::= (ps.Action, ps.CreatePermissionSet ())
+            | sa is SSP.SecurityAttribute =>
+                def perm_set = SS.PermissionSet (SSP.PermissionState.None);
+                _ = perm_set.AddPermission (sa.CreatePermission ());
+                result ::= (sa.Action, perm_set)
+            | _ => Message.FatalError (attr.Location, "given attribute must be a System.Security.Permissions.SecurityAttribute")
           }
         }
       }
@@ -213,147 +214,147 @@ namespace Nemerle.Compiler
     }
 
     internal CheckPInvoking (meth : MethodBuilder, tb : SR.Emit.TypeBuilder,
-                             attrs : SR.MethodAttributes,
-                             parm_types_array : array [SY.Type]) : SR.Emit.MethodBuilder
+                            attrs : SR.MethodAttributes,
+                            parm_types_array : array [SY.Type]) : SR.Emit.MethodBuilder
     {
       def loop (_)
       {
         | expr :: rest =>
-          def env = meth.DeclaringType.GlobalEnv;
-          match (ResolveAttribute (env, expr))
-          {
-            | Some ((tc, dllName :: parms)) when tc.Equals (InternalType.DllImport_tc) =>
+            def env = meth.DeclaringType.GlobalEnv;
+            match (ResolveAttribute (env, expr))
+            {
+              | Some ((tc, dllName :: parms)) when tc.Equals (InternalType.DllImport_tc) =>
 
-              when (meth.Attributes & NemerleModifiers.Extern == 0)
-                Message.Error (expr.Location, "only methods marked with `extern' modifier can have "
-                               "`System.Runtime.InteropServices.DllImport' attribute");
+                  when (meth.Attributes & NemerleModifiers.Extern == 0)
+                    Message.Error (expr.Location, "only methods marked with `extern' modifier can have "
+                                                  "`System.Runtime.InteropServices.DllImport' attribute");
 
-              def dllName = match(ConstantFolder.FoldConstants(env, dllName, meth.DeclaringType))
-              {
-                | <[ $(dllName : string) ]> => dllName
-                | _ =>
+                  def dllName = match(ConstantFolder.FoldConstants(env, dllName, meth.DeclaringType))
+                                 {
+                                   | <[ $(dllName : string) ]> => dllName
+                                   | _ =>
                   // emulate call typing
-                  Message.Error (dllName.Location, $"in argument #1 (dllName), constant expression of type `$(InternalType.String_tc)' required");
-                  "error" // makes SRE happy
-              }
+                                       Message.Error (dllName.Location, $"in argument #1 (dllName), constant expression of type `$(InternalType.String_tc)' required");
+                                       "error" // makes SRE happy
+                                 }
 
-              mutable callingconv = SRI.CallingConvention.Winapi;
-              mutable charset = SRI.CharSet.Ansi;
-              mutable preserve_sig = true;
-              mutable entry_point = meth.Name;
-              mutable best_fit_mapping = false;
-              mutable throw_on_unmappable = false;
-              mutable exact_spelling = false;
-              mutable set_last_error = false;
+                  mutable callingconv = SRI.CallingConvention.Winapi;
+                  mutable charset = SRI.CharSet.Ansi;
+                  mutable preserve_sig = true;
+                  mutable entry_point = meth.Name;
+                  mutable best_fit_mapping = false;
+                  mutable throw_on_unmappable = false;
+                  mutable exact_spelling = false;
+                  mutable set_last_error = false;
 
-              mutable best_fit_mapping_set = false;
-              mutable throw_on_unmappable_set = false;
-              mutable exact_spelling_set = false;
-              mutable set_last_error_set = false;
+                  mutable best_fit_mapping_set = false;
+                  mutable throw_on_unmappable_set = false;
+                  mutable exact_spelling_set = false;
+                  mutable set_last_error_set = false;
 
-              mutable set_best_fit = null;
-              mutable set_throw_on = null;
-              mutable set_exact_spelling = null;
-              mutable set_set_last_error = null;
+                  mutable set_best_fit = null;
+                  mutable set_throw_on = null;
+                  mutable set_exact_spelling = null;
+                  mutable set_set_last_error = null;
 
-              foreach (p in parms)
-                match (p)
-                {
-                  | <[ $(target : dyn) = $val ]> =>
-                    match ((target, ConstantFolder.FoldConstants (env, val)))
+                  foreach (p in parms)
+                    match (p)
                     {
-                      | ("BestFitMapping", <[ $(val : bool) ]>) =>
-                        best_fit_mapping = val;
-                        best_fit_mapping_set = true;
+                      | <[ $(target : dyn) = $val ]> =>
+                          match ((target, ConstantFolder.FoldConstants (env, val)))
+                          {
+                            | ("BestFitMapping", <[ $(val : bool) ]>) =>
+                                best_fit_mapping = val;
+                                best_fit_mapping_set = true;
 
-                      | ("CallingConvention", PT.PExpr.Literal (Literal.Enum (l, _, _))) =>
-                        callingconv = l.AsObject (InternalType) :> SRI.CallingConvention;
+                            | ("CallingConvention", PT.PExpr.Literal (Literal.Enum (l, _, _))) =>
+                                callingconv = l.AsObject (InternalType) :> SRI.CallingConvention;
 
-                      | ("CharSet", PT.PExpr.Literal (Literal.Enum (l, _, _))) =>
-                        charset = l.AsObject (InternalType) :> SRI.CharSet;
+                            | ("CharSet", PT.PExpr.Literal (Literal.Enum (l, _, _))) =>
+                                charset = l.AsObject (InternalType) :> SRI.CharSet;
 
-                      | ("EntryPoint", <[ $(val : string) ]>) =>
-                        entry_point = val;
+                            | ("EntryPoint", <[ $(val : string) ]>) =>
+                                entry_point = val;
 
-                      | ("ExactSpelling", <[ $(val : bool) ]>) =>
-                        exact_spelling = val;
-                        exact_spelling_set = true;
+                            | ("ExactSpelling", <[ $(val : bool) ]>) =>
+                                exact_spelling = val;
+                                exact_spelling_set = true;
 
-                      | ("PreserveSig", <[ $(val : bool) ]>) =>
-                        preserve_sig = val;
+                            | ("PreserveSig", <[ $(val : bool) ]>) =>
+                                preserve_sig = val;
 
-                      | ("SetLastError", <[ $(val : bool) ]>) =>
-                        set_last_error = val;
-                        set_last_error_set = true;
+                            | ("SetLastError", <[ $(val : bool) ]>) =>
+                                set_last_error = val;
+                                set_last_error_set = true;
 
-                      | ("ThrowOnUnmappableChar", <[ $(val : bool) ]>) =>
-                        throw_on_unmappable = val;
-                        throw_on_unmappable_set = true;
+                            | ("ThrowOnUnmappableChar", <[ $(val : bool) ]>) =>
+                                throw_on_unmappable = val;
+                                throw_on_unmappable_set = true;
 
-                      | (name, val) => Message.Error (val.Location,
-                                                      $"value is not valid for parameter $name")
+                            | (name, val) => Message.Error (val.Location,
+                                                            $"value is not valid for parameter $name")
+                          }
+                      | _ => Message.Error (p.Location, "unnamed DllImport parameter")
                     }
-                  | _ => Message.Error (p.Location, "unnamed DllImport parameter")
-                }
 
-              when (throw_on_unmappable_set || best_fit_mapping_set || exact_spelling_set || set_last_error_set)
-              {
-                set_best_fit = typeof (SR.Emit.MethodBuilder).GetMethod ("set_BestFitMapping",
-                                 BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                set_throw_on = typeof (SR.Emit.MethodBuilder).GetMethod ("set_ThrowOnUnmappableChar",
-                                 BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                set_exact_spelling = typeof (SR.Emit.MethodBuilder).GetMethod ("set_ExactSpelling",
-                                 BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                set_set_last_error = typeof (SR.Emit.MethodBuilder).GetMethod ("set_SetLastError",
-                                 BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-              }
+                  when (throw_on_unmappable_set || best_fit_mapping_set || exact_spelling_set || set_last_error_set)
+                  {
+                    set_best_fit = typeof (SR.Emit.MethodBuilder).GetMethod ("set_BestFitMapping",
+                                                                             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                    set_throw_on = typeof (SR.Emit.MethodBuilder).GetMethod ("set_ThrowOnUnmappableChar",
+                                                                             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                    set_exact_spelling = typeof (SR.Emit.MethodBuilder).GetMethod ("set_ExactSpelling",
+                                                                                   BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                    set_set_last_error = typeof (SR.Emit.MethodBuilder).GetMethod ("set_SetLastError",
+                                                                                   BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                  }
 
-              when (throw_on_unmappable_set || best_fit_mapping_set)
-              {
-                when ((set_best_fit == null) || (set_throw_on == null))
-                {
-                  Message.Error ("The ThrowOnUnmappableChar and BestFitMapping"
-                                 " attributes can only be emitted when running on the mono runtime.");
-                }
-              }
+                  when (throw_on_unmappable_set || best_fit_mapping_set)
+                  {
+                    when ((set_best_fit == null) || (set_throw_on == null))
+                    {
+                      Message.Error ("The ThrowOnUnmappableChar and BestFitMapping"
+                                     " attributes can only be emitted when running on the mono runtime.");
+                    }
+                  }
 
-              when (exact_spelling && set_exact_spelling == null)
-                charset |= (0x01 :> SRI.CharSet);
+                  when (exact_spelling && set_exact_spelling == null)
+                    charset |= (0x01 :> SRI.CharSet);
 
-              when (set_last_error && set_set_last_error == null)
-                charset |= (0x40 :> SRI.CharSet);
+                  when (set_last_error && set_set_last_error == null)
+                    charset |= (0x40 :> SRI.CharSet);
 
-              def mb = tb.DefinePInvokeMethod (meth.Name, dllName, entry_point,
-                                               attrs | SR.MethodAttributes.HideBySig | SR.MethodAttributes.PinvokeImpl,
-                                               SR.CallingConventions.Standard,
-                                               meth.ReturnType.GetSystemType (),
-                                               parm_types_array, callingconv, charset);
+                  def mb = tb.DefinePInvokeMethod (meth.Name, dllName, entry_point,
+                                                   attrs | SR.MethodAttributes.HideBySig | SR.MethodAttributes.PinvokeImpl,
+                                                   SR.CallingConventions.Standard,
+                                                   meth.ReturnType.GetSystemType (),
+                                                   parm_types_array, callingconv, charset);
 
-              when (preserve_sig)
-                mb.SetImplementationFlags (SR.MethodImplAttributes.PreserveSig);
+                  when (preserve_sig)
+                    mb.SetImplementationFlags (SR.MethodImplAttributes.PreserveSig);
 
-              when (throw_on_unmappable_set)
-                _ = set_throw_on.Invoke (mb, SR.BindingFlags.Default, null,
-                                         array [ throw_on_unmappable : object], null);
+                  when (throw_on_unmappable_set)
+                    _ = set_throw_on.Invoke (mb, SR.BindingFlags.Default, null,
+                                             array [ throw_on_unmappable : object], null);
 
-              when (best_fit_mapping_set)
-                _ = set_best_fit.Invoke (mb, SR.BindingFlags.Default, null,
-                                         array [ best_fit_mapping : object], null);
+                  when (best_fit_mapping_set)
+                    _ = set_best_fit.Invoke (mb, SR.BindingFlags.Default, null,
+                                             array [ best_fit_mapping : object], null);
 
-              when (exact_spelling_set && set_exact_spelling != null)
-                _ = set_exact_spelling.Invoke (mb, SR.BindingFlags.Default, null,
-                                         array [ exact_spelling : object], null);
+                  when (exact_spelling_set && set_exact_spelling != null)
+                    _ = set_exact_spelling.Invoke (mb, SR.BindingFlags.Default, null,
+                                                   array [ exact_spelling : object], null);
 
-              when (set_last_error_set && set_set_last_error != null)
-                _ = set_set_last_error.Invoke (mb, SR.BindingFlags.Default, null,
-                                         array [ set_last_error : object], null);
+                  when (set_last_error_set && set_set_last_error != null)
+                    _ = set_set_last_error.Invoke (mb, SR.BindingFlags.Default, null,
+                                                   array [ set_last_error : object], null);
 
-              meth.GetModifiers().custom_attrs =
-                meth.GetModifiers().custom_attrs.Filter(x => x : object != expr);
-              mb
+                  meth.GetModifiers().custom_attrs =
+                                                      meth.GetModifiers().custom_attrs.Filter(x => x : object != expr);
+                  mb
 
-            | _ => loop (rest)
-          }
+              | _ => loop (rest)
+            }
         | [] => null
       }
       loop (meth.GetModifiers ().GetCustomAttributes ())
@@ -373,44 +374,44 @@ namespace Nemerle.Compiler
       when(mb.DeclaringType.IsInterface)
       {
         Message.Error(getErrorLocation(),
-          "Conditional attribute is not valid on interface members");
+                      "Conditional attribute is not valid on interface members");
         Nemerle.Imperative.Return();
       }
 
       when(mb.IsConstructor
         || (mb.GetModifiers().mods %&& NemerleModifiers.SpecialName
-            && mb.Header.Name.StartsWith("op_")))
+           && mb.Header.Name.StartsWith("op_")))
       {
         Message.Error(getErrorLocation(),
-          "Conditional attribute is not valid on constructor, operator, or explicit interface implementation");
+                      "Conditional attribute is not valid on constructor, operator, or explicit interface implementation");
         Nemerle.Imperative.Return();
       }
 
       when(mb.ImplementedMethods is (_, ifaceMember) :: _)
       {
         Message.Error(getErrorLocation(),
-          $"Conditional member `$mb' cannot implement interface member `$ifaceMember'");
+                      $"Conditional member `$mb' cannot implement interface member `$ifaceMember'");
         Nemerle.Imperative.Return();
       }
 
       when(mb.GetModifiers().mods %&& NemerleModifiers.Override)
       {
         Message.Error(getErrorLocation(),
-          $"Conditional attribute is not valid on `$mb' because it is an override method");
+                      $"Conditional attribute is not valid on `$mb' because it is an override method");
         Nemerle.Imperative.Return();
       }
 
       unless(mb.ReturnType.Equals(FixedType.Void()))
       {
         Message.Error(getErrorLocation(),
-          $"Conditional attribute is not valid on `$mb' because its return type is not void");
+                      $"Conditional attribute is not valid on `$mb' because its return type is not void");
         Nemerle.Imperative.Return();
       }
 
       foreach(parm when parm.kind == ParmKind.Out in mb.GetParameters())
       {
         Message.Error(getErrorLocation(),
-          $"conditional member `$mb' cannot have an out parameter");
+                      $"conditional member `$mb' cannot have an out parameter");
         Nemerle.Imperative.Break();
       }
     }
@@ -421,7 +422,7 @@ namespace Nemerle.Compiler
       // so using LibraryReference.ExternalTypeInfo is good enought here.
       //
       ti is LibraryReference.ExternalTypeInfo
-        && typeof(SSP.SecurityAttribute).IsAssignableFrom ((ti :> LibraryReference.ExternalTypeInfo).SystemType)
+      && typeof(SSP.SecurityAttribute).IsAssignableFrom ((ti :> LibraryReference.ExternalTypeInfo).SystemType)
     }
 
     private compile_expr(env : GlobalEnv, expr : PT.PExpr, typer : Typer, mutable expected : TypeVar = null) : object * FixedType
@@ -431,16 +432,16 @@ namespace Nemerle.Compiler
         match (fixedType)
         {
           | FixedType.Class (tc, args) =>
-            def is_free (a) { !(a is FixedType) }
-            if (args.Exists (is_free))
-            {
-              when (!args.ForAll (is_free))
-                Message.Error(loc, "to create open generic type all arguments must be open `_'");
+              def is_free (a) { !(a is FixedType) }
+              if (args.Exists (is_free))
+              {
+                when (!args.ForAll (is_free))
+                  Message.Error(loc, "to create open generic type all arguments must be open `_'");
 
-              (tc.SystemType, InternalType.Type)
-            }
-            else
-              (fixedType.GetSystemType(), InternalType.Type)
+                (tc.SystemType, InternalType.Type)
+              }
+              else
+                (fixedType.GetSystemType(), InternalType.Type)
 
           | _ => Message.FatalError(loc, "invalid type in attribute parameter")
         }
@@ -460,22 +461,22 @@ namespace Nemerle.Compiler
         | TExpr.Literal(lit) => (lit.AsObject(InternalType), lit.GetInternalType(InternalType))
         | TExpr.TypeConversion(subExpr, t, ConversionKind.UpCast, _) when subExpr.Type.TryRequire(t) => convert(subExpr)
         | TExpr.TypeConversion(TExpr.Literal(lit) as e, t, ConversionKind.UpCast, _) => 
-          match (ConstantFolder.ConvertLiteral(lit, t.Fix()))
-          {
-            | Some(convertedLit) => convert(TExpr.Literal(e.Location, t, convertedLit))
-            | _ => Message.FatalError(tExpr.Location, $"Type conversion from $(e.Type) to $t in attribute a argument is unsupported.");
-          }
+            match (ConstantFolder.ConvertLiteral(lit, t.Fix()))
+            {
+              | Some(convertedLit) => convert(TExpr.Literal(e.Location, t, convertedLit))
+              | _ => Message.FatalError(tExpr.Location, $"Type conversion from $(e.Type) to $t in attribute a argument is unsupported.");
+            }
 
         | TExpr.TypeOf(type) => compile_type(tExpr.Location, type.Fix())
         | TExpr.Array(elems, [_]) => 
-          def objects      = elems.MapToArray(e => convert(e)[0]);
-          def elemType     = tExpr.Type.Fix();
-          (objects : object, elemType)
+            def objects      = elems.MapToArray(e => convert(e)[0]);
+            def elemType     = tExpr.Type.Fix();
+            (objects : object, elemType)
 
         | TExpr.Array => Message.FatalError(tExpr.Location, "only single-dimensional arrays allowed in attributes")
         | _ => Message.FatalError(tExpr.Location, $"only constant expressions allowed in attributes: $expr ($(tExpr.Type))")
       }
-          
+
       convert(tExpr)
     }
 
@@ -493,86 +494,86 @@ namespace Nemerle.Compiler
       mutable properties = [];
 
       foreach (parm in parms)
-      {
-        | <[ $(n : name) = $expr ]> =>
-          def name = n.Id;
-          def expr = ConstantFolder.FoldConstants(env, expr);
-          def (obj, ty) = compile_expr(env, expr, typer);
-          def problem() { Message.FatalError($"the type $(attr.FullName) has no field nor property named `$name'") };
-          def (is_prop, mem) =
-            match (attr.LookupMember(name))
-            {
-              | [mem] =>
-                match (mem.MemberKind)
+        {
+          | <[ $(n : name) = $expr ]> =>
+              def name = n.Id;
+              def expr = ConstantFolder.FoldConstants(env, expr);
+              def (obj, ty) = compile_expr(env, expr, typer);
+              def problem() { Message.FatalError($"the type $(attr.FullName) has no field nor property named `$name'") };
+              def (is_prop, mem) =
+                                    match (attr.LookupMember(name))
+                                    {
+                                      | [mem] =>
+                                          match (mem.MemberKind)
+                                          {
+                                            | MemberKinds.Field    => (false, mem)
+                                            | MemberKinds.Property => (true, mem)
+                                            | _ => problem()
+                                          }
+                                      | _ => problem()
+                                    };
+              def handle = mem.GetHandle();
+              assert(handle != null);
+              def memberType = mem.GetMemType();
+
+              if (memberType.Unify(ty))
+                if (is_prop)
                 {
-                  | MemberKinds.Field    => (false, mem)
-                  | MemberKinds.Property => (true, mem)
-                  | _ => problem()
+                  property_infos ::= handle :> SR.PropertyInfo;
+                  properties ::= obj;
                 }
-              | _ => problem()
-            };
-          def handle = mem.GetHandle();
-          assert(handle != null);
-          def memberType = mem.GetMemType();
+                else
+                {
+                  field_infos ::= handle :> SR.FieldInfo;
+                  fields ::= obj;
+                }
+              else
+                Message.FatalError ($"the member `$name' has type $(mem.GetMemType()) while the value assigned has type $ty")
 
-          if (memberType.Unify(ty))
-            if (is_prop)
-            {
-              property_infos ::= handle :> SR.PropertyInfo;
-              properties ::= obj;
-            }
-            else
-            {
-              field_infos ::= handle :> SR.FieldInfo;
-              fields ::= obj;
-            }
-          else
-            Message.FatalError ($"the member `$name' has type $(mem.GetMemType()) while the value assigned has type $ty")
-
-        | _ =>
-          def (obj, ty) = compile_expr(env, parm, typer);
-          ctor_parm_types ::= ty;
-          ctor_parms ::= obj;
-      }
+          | _ =>
+              def (obj, ty) = compile_expr(env, parm, typer);
+              ctor_parm_types ::= ty;
+              ctor_parms ::= obj;
+        }
 
       def proper_ctor = 
       {
-        mutable overloads = [];
+                         mutable overloads = [];
 
-        foreach (meth is IMethod when meth.IsConstructor && !meth.IsPrivate in attr.LookupMember(".ctor"))
-        {
-          def ty   = meth.GetMemType();
-          def from = attr.GetMemType();
-          
-          overloads ::= OverloadPossibility(typer, ty, null, from, meth);
+                         foreach (meth is IMethod when meth.IsConstructor && !meth.IsPrivate in attr.LookupMember(".ctor"))
+                         {
+                           def ty   = meth.GetMemType();
+                           def from = attr.GetMemType();
 
-          when (meth.IsVarArgs)
-          {
-            def op = OverloadPossibility (typer, ty, null, from, meth);
-            op.VarArgs = true;
-            overloads ::= op;
-          }
-        }
+                           overloads ::= OverloadPossibility(typer, ty, null, from, meth);
 
-        def parms = ctor_parm_types.RevMap(ty => Parm(TExpr.DefaultValue(ty)));
+                           when (meth.IsVarArgs)
+                           {
+                             def op = OverloadPossibility (typer, ty, null, from, meth);
+                             op.VarArgs = true;
+                             overloads ::= op;
+                           }
+                         }
 
-        match(typer.ResolveOverload(overloads, parms, Manager.InternalType.Void, false, LocationStack.Top()))
-        {
-          | [] => Message.FatalError($"none of the constructors of `$(attr.FullName)'matches positional argument types $(ctor_parm_types.Rev())");
-          | [one] => one.Member :> IMethod
-          | lst =>
-            Message.Error( $"ambiguity between custom attribute constructors $lst");
-            lst.Head.Member :> IMethod
-        }
+                         def parms = ctor_parm_types.RevMap(ty => Parm(TExpr.DefaultValue(ty)));
+
+                         match(typer.ResolveOverload(overloads, parms, Manager.InternalType.Void, false, LocationStack.Top()))
+                         {
+                           | [] => Message.FatalError($"none of the constructors of `$(attr.FullName)'matches positional argument types $(ctor_parm_types.Rev())");
+                           | [one] => one.Member :> IMethod
+                           | lst =>
+                               Message.Error( $"ambiguity between custom attribute constructors $lst");
+                               lst.Head.Member :> IMethod
+                         }
       };
 
       when(proper_ctor.IsVarArgs)
       {
         def (var_parms, normal_parms) = NList.Partition(ctor_parms,
           {
-            def required_parms_count = proper_ctor.GetParameters().Length;
-            def actual_parms_count = ctor_parms.Length;
-            mutable count = actual_parms_count - required_parms_count;
+                                                        def required_parms_count = proper_ctor.GetParameters().Length;
+                                                        def actual_parms_count = ctor_parms.Length;
+                                                        mutable count = actual_parms_count - required_parms_count;
             fun(_)
             {
               def is_var_parm = count >= 0;
@@ -641,10 +642,10 @@ namespace Nemerle.Compiler
         match (MacroRegistry.lookup_macro (env, attr, suff)) {
           | None => false
           | Some =>
-            def expansion = AssemblyAttributeMacroExpansion (MacroTargets.Assembly, phase,
-                                                             attr, [], null, null, env);
-            AddMacroExpansion (expansion);
-            true
+              def expansion = AssemblyAttributeMacroExpansion (MacroTargets.Assembly, phase,
+                                                               attr, [], null, null, env);
+              AddMacroExpansion (expansion);
+              true
         }
       }
       def b1 = add (MacroPhase.BeforeInheritance);
@@ -656,6 +657,73 @@ namespace Nemerle.Compiler
         assembly_attributes.Add (env, attr);
     }
 
+    internal GetInformationalAssemblyAttributes() : list[SRE.CustomAttributeBuilder]
+    {
+      def attributeList = SCG.List.[SRE.CustomAttributeBuilder]();
+	  def typeList = SCG.List.[System.Type]();
+      def ctorParameters = array[typeof(string)];
+    
+      
+      foreach ((env, attr) in assembly_attributes)
+      {
+        /* store resolved attribute */
+        def (tc, parms) = Manager.AttributeCompiler.CheckAttribute (env, attr);
+
+        def take_string (pars) {
+          | [ <[ $(x : string) ]> ] => x
+          | _ =>
+              Message.FatalError (attr.Location, "given attribute must have single string as parameter")
+        }
+		
+		def addAttributeForType(type)
+        {
+	     def valueString = take_string(parms);
+         def ctor = type.GetConstructor(ctorParameters);
+         def ctorArgs = array[valueString];
+		 if(typeList.Contains(type))
+		 {
+		     Message.Warning (attr.Location, "given attribute is occurred more than once")
+		 }
+		 else
+         {		 
+          SRE.CustomAttributeBuilder(ctor, ctorArgs) |> attributeList.Add;
+		  typeList.Add(type);
+		 }
+		  
+        }
+        if (tc.Equals (InternalType.AssemblyCompanyAttribute_tc))
+        {
+          addAttributeForType(typeof(SR.AssemblyCompanyAttribute))
+        }
+        else if (tc.Equals (InternalType.AssemblyCopyrightAttribute_tc))
+        {
+            addAttributeForType(typeof(SR.AssemblyCopyrightAttribute)) 
+        }
+        else if (tc.Equals (InternalType.AssemblyDescriptionAttribute_tc))
+        {
+            addAttributeForType(typeof(SR.AssemblyDescriptionAttribute)) 
+        }
+        else if (tc.Equals (InternalType.AssemblyFileVersionAttribute_tc))
+        {
+           addAttributeForType(typeof(SR.AssemblyFileVersionAttribute))
+        }
+        else if (tc.Equals (InternalType.AssemblyProductAttribute_tc))
+        {
+           addAttributeForType(typeof(SR.AssemblyProductAttribute))
+        }
+        else if (tc.Equals (InternalType.AssemblyTitleAttribute_tc))
+        {
+           addAttributeForType(typeof(SR.AssemblyTitleAttribute))
+        }
+        else
+        {
+           
+        }
+      
+      }
+      attributeList.NToList();
+      
+    }
     internal CreateAssemblyName () : SR.AssemblyName
     {
       /* create an assembly name and set its properties according to defined
@@ -675,7 +743,7 @@ namespace Nemerle.Compiler
         def take_string (pars) {
           | [ <[ $(x : string) ]> ] => x
           | _ =>
-            Message.FatalError (attr.Location, "given attribute must have single string as parameter")
+              Message.FatalError (attr.Location, "given attribute must have single string as parameter")
         }
         if (tc.Equals (InternalType.AssemblyVersionAttribute_tc))
         {
@@ -689,22 +757,22 @@ namespace Nemerle.Compiler
             def verint = ver.Map(x => if (x == "*") -1 else (SY.UInt16.Parse(x) :> int));
 
             version_object =
-              match (verint) {
-                | [x1] => SY.Version (x1.ToString ())
-                | [x1, x2] => SY.Version (x1, x2)
-                | [x1, x2, -1] =>
-                  def spanBuild = SY.DateTime.Now.Subtract (SY.DateTime (2000, 1, 1));
-                  def spanRevision = SY.DateTime.Now.Subtract (SY.DateTime.Today);
-                  SY.Version (x1, x2, spanBuild.Days, (spanRevision.Ticks / 20000000) :> int)
-                | [x1, x2, x3] => SY.Version (x1, x2, x3)
-                | [x1, x2, x3, -1] =>
-                  def spanRevision = SY.DateTime.Now.Subtract (SY.DateTime.Today);
-                  SY.Version (x1, x2, x3, (spanRevision.Ticks / 20000000) :> int)
-                | [x1, x2, x3, x4] => SY.Version (x1, x2, x3, x4)
-                | _ =>
-                  Message.Error (attr.Location, "invalid format of version attribute");
-                  SY.Version ();
-              }
+                              match (verint) {
+                                | [x1] => SY.Version (x1.ToString ())
+                                | [x1, x2] => SY.Version (x1, x2)
+                                | [x1, x2, -1] =>
+                                    def spanBuild = SY.DateTime.Now.Subtract (SY.DateTime (2000, 1, 1));
+                                    def spanRevision = SY.DateTime.Now.Subtract (SY.DateTime.Today);
+                                    SY.Version (x1, x2, spanBuild.Days, (spanRevision.Ticks / 20000000) :> int)
+                                | [x1, x2, x3] => SY.Version (x1, x2, x3)
+                                | [x1, x2, x3, -1] =>
+                                    def spanRevision = SY.DateTime.Now.Subtract (SY.DateTime.Today);
+                                    SY.Version (x1, x2, x3, (spanRevision.Ticks / 20000000) :> int)
+                                | [x1, x2, x3, x4] => SY.Version (x1, x2, x3, x4)
+                                | _ =>
+                                    Message.Error (attr.Location, "invalid format of version attribute");
+                                    SY.Version ();
+                              }
           }
           catch {
             | _ is SY.OverflowException =>
@@ -715,15 +783,15 @@ namespace Nemerle.Compiler
           an.Version = version_object;
         }
         else if (tc.Equals (InternalType.AssemblyKeyFileAttribute_tc))
-        {
-          def key = take_string (parms);
-          if (an.KeyPair != null)
-            Message.Warning (attr.Location, "AssemblyKeyFile attribute will be ignored, as key file was already specified")
-          else
-            when (key != "") an.KeyPair = read_keypair (attr.Location, key);
-        }
-        else when (tc.Equals (InternalType.AssemblyCultureAttribute_tc))
-          an.CultureInfo = SY.Globalization.CultureInfo (take_string (parms));
+             {
+               def key = take_string (parms);
+               if (an.KeyPair != null)
+                 Message.Warning (attr.Location, "AssemblyKeyFile attribute will be ignored, as key file was already specified")
+               else
+                 when (key != "") an.KeyPair = read_keypair (attr.Location, key);
+             }
+             else when (tc.Equals (InternalType.AssemblyCultureAttribute_tc))
+                    an.CultureInfo = SY.Globalization.CultureInfo (take_string (parms));
       }
       an
     }
@@ -794,12 +862,12 @@ namespace Nemerle.Compiler
       {
         try {
           def (m, parms) =
-            match (MacroRegistry.lookup_macro (ti.GlobalEnv, expr, suff))
-            {
-              | Some ((_, m, parms)) => (m, parms)
-              | _ => Util.ice ("macro is not a macro?" +
-                               PrettyPrint.SprintExpr (None (), expr))
-            };
+                            match (MacroRegistry.lookup_macro (ti.GlobalEnv, expr, suff))
+                            {
+                              | Some ((_, m, parms)) => (m, parms)
+                              | _ => Util.ice ("macro is not a macro?" +
+                                               PrettyPrint.SprintExpr (None (), expr))
+                            };
 
           // check if macro needs to be saved in metadata
           // it should be done only if it will be inherited in some derived class
@@ -812,8 +880,8 @@ namespace Nemerle.Compiler
             def serialized = <[
               Nemerle.Internal.MacroAttribute ($(name : string),
             //                                   $(ti.env.GetMacroContext () : int),
-                                               0,
-                                               $(concatenated : string))
+                                              0,
+                                              $(concatenated : string))
             ]>;
             def error = adder (ti.Manager.AttributeCompiler.CompileAttribute (ti.GlobalEnv, ti, serialized));
             when (error != null)

--- a/ncc/hierarchy/CustomAttribute.n
+++ b/ncc/hierarchy/CustomAttribute.n
@@ -660,10 +660,13 @@ namespace Nemerle.Compiler
     internal GetInformationalAssemblyAttributes() : list[SRE.CustomAttributeBuilder]
     {
       def attributeList = SCG.List.[SRE.CustomAttributeBuilder]();
-	  def typeList = SCG.List.[System.Type]();
+      def typeList = SCG.List.[System.Type]();
       def ctorParameters = array[typeof(string)];
-    
-      
+
+      mutable hitFileVersion = false;
+      mutable hitAssemblyVersion = false;
+      mutable assemblyVersionString;
+      mutable location;
       foreach ((env, attr) in assembly_attributes)
       {
         /* store resolved attribute */
@@ -674,37 +677,40 @@ namespace Nemerle.Compiler
           | _ =>
               Message.FatalError (attr.Location, "given attribute must have single string as parameter")
         }
-		
-		def addAttributeForType(type)
+
+        def addAttributeForType(type)
         {
-	     def valueString = take_string(parms);
-         def ctor = type.GetConstructor(ctorParameters);
-         def ctorArgs = array[valueString];
-		 if(typeList.Contains(type))
-		 {
-		     Message.Warning (attr.Location, "given attribute is occurred more than once")
-		 }
-		 else
-         {		 
-          SRE.CustomAttributeBuilder(ctor, ctorArgs) |> attributeList.Add;
-		  typeList.Add(type);
-		 }
-		  
+          def valueString = take_string(parms);
+          def ctor = type.GetConstructor(ctorParameters);
+          def ctorArgs = array[valueString];
+          if(typeList.Contains(type))
+          {
+            Message.Warning (attr.Location, "given attribute is occurred more than once")
+          }
+          else
+          {		 
+            SRE.CustomAttributeBuilder(ctor, ctorArgs) |> attributeList.Add;
+            typeList.Add(type);
+          }
+
         }
+     
+        
         if (tc.Equals (InternalType.AssemblyCompanyAttribute_tc))
         {
           addAttributeForType(typeof(SR.AssemblyCompanyAttribute))
         }
         else if (tc.Equals (InternalType.AssemblyCopyrightAttribute_tc))
         {
-            addAttributeForType(typeof(SR.AssemblyCopyrightAttribute)) 
+           addAttributeForType(typeof(SR.AssemblyCopyrightAttribute)) 
         }
         else if (tc.Equals (InternalType.AssemblyDescriptionAttribute_tc))
         {
-            addAttributeForType(typeof(SR.AssemblyDescriptionAttribute)) 
+          addAttributeForType(typeof(SR.AssemblyDescriptionAttribute)) 
         }
         else if (tc.Equals (InternalType.AssemblyFileVersionAttribute_tc))
         {
+           hitFileVersion = true;
            addAttributeForType(typeof(SR.AssemblyFileVersionAttribute))
         }
         else if (tc.Equals (InternalType.AssemblyProductAttribute_tc))
@@ -713,16 +719,70 @@ namespace Nemerle.Compiler
         }
         else if (tc.Equals (InternalType.AssemblyTitleAttribute_tc))
         {
-           addAttributeForType(typeof(SR.AssemblyTitleAttribute))
+          addAttributeForType(typeof(SR.AssemblyTitleAttribute))
+        }
+        else if (tc.Equals (InternalType.AssemblyVersionAttribute_tc))
+        {         
+          hitAssemblyVersion = true;
+          assemblyVersionString = take_string(parms);  
+          location = attr.Location;
+          //an.Version = ParseVersion(take_string(parms), attr.Location);
         }
         else
         {
-           
+
         }
-      
+
+      }
+      when(!hitFileVersion && hitAssemblyVersion)
+      {
+        def type =  typeof(SR.AssemblyFileVersionAttribute);
+        def ctor = type.GetConstructor(ctorParameters);
+        def version = ParseVersion(assemblyVersionString, location).ToString();
+        def ctorArgs = array[version];
+        SRE.CustomAttributeBuilder(ctor, ctorArgs) |> attributeList.Add;
+        
       }
       attributeList.NToList();
-      
+
+    }
+
+    ParseVersion  (versionString : string, location : Location) : SY.Version
+    {
+      _ = this;
+        // spec for parsing version is quite interesting
+          // http://msdn.microsoft.com/library/en-us/cpref/html/frlrfsystemreflectionassemblyversionattributeclassctortopic.asp
+      def ver = NString.Split (versionString, array ['.']);
+
+      mutable version_object = null;
+      try
+      {
+        def verint = ver.Map(x => if (x == "*") -1 else (SY.UInt16.Parse(x) :> int));
+
+        version_object =
+                          match (verint) {
+                            | [x1] => SY.Version (x1.ToString ())
+                            | [x1, x2] => SY.Version (x1, x2)
+                            | [x1, x2, -1] =>
+                                def spanBuild = SY.DateTime.Now.Subtract (SY.DateTime (2000, 1, 1));
+                                def spanRevision = SY.DateTime.Now.Subtract (SY.DateTime.Today);
+                                SY.Version (x1, x2, spanBuild.Days, (spanRevision.Ticks / 20000000) :> int)
+                            | [x1, x2, x3] => SY.Version (x1, x2, x3)
+                            | [x1, x2, x3, -1] =>
+                                def spanRevision = SY.DateTime.Now.Subtract (SY.DateTime.Today);
+                                SY.Version (x1, x2, x3, (spanRevision.Ticks / 20000000) :> int)
+                            | [x1, x2, x3, x4] => SY.Version (x1, x2, x3, x4)
+                            | _ =>
+                                Message.Error (location, "invalid format of version attribute");
+                                SY.Version ();
+                          }
+      }
+      catch {
+        | _ is SY.OverflowException =>
+          Message.Error (location, "wrong format of version attribute");
+          version_object = SY.Version ();
+      }
+      version_object;
     }
     internal CreateAssemblyName () : SR.AssemblyName
     {
@@ -746,41 +806,8 @@ namespace Nemerle.Compiler
               Message.FatalError (attr.Location, "given attribute must have single string as parameter")
         }
         if (tc.Equals (InternalType.AssemblyVersionAttribute_tc))
-        {
-          // spec for parsing version is quite interesting
-          // http://msdn.microsoft.com/library/en-us/cpref/html/frlrfsystemreflectionassemblyversionattributeclassctortopic.asp
-          def ver = NString.Split (take_string (parms), array ['.']);
-
-          mutable version_object = null;
-          try
-          {
-            def verint = ver.Map(x => if (x == "*") -1 else (SY.UInt16.Parse(x) :> int));
-
-            version_object =
-                              match (verint) {
-                                | [x1] => SY.Version (x1.ToString ())
-                                | [x1, x2] => SY.Version (x1, x2)
-                                | [x1, x2, -1] =>
-                                    def spanBuild = SY.DateTime.Now.Subtract (SY.DateTime (2000, 1, 1));
-                                    def spanRevision = SY.DateTime.Now.Subtract (SY.DateTime.Today);
-                                    SY.Version (x1, x2, spanBuild.Days, (spanRevision.Ticks / 20000000) :> int)
-                                | [x1, x2, x3] => SY.Version (x1, x2, x3)
-                                | [x1, x2, x3, -1] =>
-                                    def spanRevision = SY.DateTime.Now.Subtract (SY.DateTime.Today);
-                                    SY.Version (x1, x2, x3, (spanRevision.Ticks / 20000000) :> int)
-                                | [x1, x2, x3, x4] => SY.Version (x1, x2, x3, x4)
-                                | _ =>
-                                    Message.Error (attr.Location, "invalid format of version attribute");
-                                    SY.Version ();
-                              }
-          }
-          catch {
-            | _ is SY.OverflowException =>
-              Message.Error (attr.Location, "wrong format of version attribute");
-              version_object = SY.Version ();
-          }
-
-          an.Version = version_object;
+        {         
+          an.Version = ParseVersion(take_string(parms), attr.Location);
         }
         else if (tc.Equals (InternalType.AssemblyKeyFileAttribute_tc))
              {


### PR DESCRIPTION
There is only one problem with it. Unfortunately SRE only supports single win32 resource to be embeded to the file. So my solution is okay, but if you use the compiler with /win32res switch, the values of the attributes are ignored. Currently I don't have time for a better solution , but this solution is better than current situation imho.
