### PR TITLE
fix define constants project directive.

### DIFF
--- a/VsIntegration/Nemerle.VisualStudio/Project/ProjectInfo.cs
+++ b/VsIntegration/Nemerle.VisualStudio/Project/ProjectInfo.cs
@@ -489,7 +489,8 @@ namespace Nemerle.VisualStudio.Project
 
 			if (!string.IsNullOrEmpty(defineConstants))
 			{
-				var defines = defineConstants.Replace(" \t\r\n", String.Empty).Split(';');
+				var defines = defineConstants
+					.Split(new char[]{';', ' ', '\r', '\n', '\t'}, StringSplitOptions.RemoveEmptyEntries);
 
 				foreach (var define in defines)
 					options.DefineConstant(define);

--- a/snippets/VS2010/Nemerle.VisualStudio/Project/ProjectInfo.cs
+++ b/snippets/VS2010/Nemerle.VisualStudio/Project/ProjectInfo.cs
@@ -501,8 +501,8 @@ namespace Nemerle.VisualStudio.Project
 
 			if (!string.IsNullOrEmpty(defineConstants))
 			{
-				var defines = defineConstants.Replace(" \t\r\n", String.Empty)
-					.Split(new char[]{';'}, StringSplitOptions.RemoveEmptyEntries);
+				var defines = defineConstants
+					.Split(new char[]{';', ' ', '\r', '\n', '\t'}, StringSplitOptions.RemoveEmptyEntries);
 
 				foreach (var define in defines)
 					options.DefineConstant(define.Trim());

--- a/tools/msbuild-task/MSBuildTask.cs
+++ b/tools/msbuild-task/MSBuildTask.cs
@@ -196,9 +196,9 @@ namespace Nemerle.Tools.MSBuildTask
 			if (IndentationSyntax)
 				commandLine.AppendSwitch("\n/indentation-syntax");
 			commandLine.AppendSwitchIfNotNull("\n/doc:", this.DocumentationFile);
-			def defines = base.DefineConstants
+			var defines = base.DefineConstants
 				.Split(new char[]{';', ' ', '\r', '\n', '\t'}, StringSplitOptions.RemoveEmptyEntries);
-			commandLine.AppendSwitchUnquotedIfNotNull("\n/define:", String.Join(defines, ';'));
+			commandLine.AppendSwitchUnquotedIfNotNull("\n/define:", String.Join(";", defines));
 			commandLine.AppendSwitchIfNotNull("\n/win32res:", base.Win32Resource);
 			commandLine.AppendSwitchIfNotNull("\n/platform:", this.Platform);
 

--- a/tools/msbuild-task/MSBuildTask.cs
+++ b/tools/msbuild-task/MSBuildTask.cs
@@ -196,7 +196,9 @@ namespace Nemerle.Tools.MSBuildTask
 			if (IndentationSyntax)
 				commandLine.AppendSwitch("\n/indentation-syntax");
 			commandLine.AppendSwitchIfNotNull("\n/doc:", this.DocumentationFile);
-			commandLine.AppendSwitchUnquotedIfNotNull("\n/define:", base.DefineConstants);
+			def defines = base.DefineConstants
+				.Split(new char[]{';', ' ', '\r', '\n', '\t'}, StringSplitOptions.RemoveEmptyEntries);
+			commandLine.AppendSwitchUnquotedIfNotNull("\n/define:", String.Join(defines, ';'));
 			commandLine.AppendSwitchIfNotNull("\n/win32res:", base.Win32Resource);
 			commandLine.AppendSwitchIfNotNull("\n/platform:", this.Platform);
 

--- a/tools/msbuild-task/MSBuildTask.n
+++ b/tools/msbuild-task/MSBuildTask.n
@@ -162,7 +162,7 @@ namespace Nemerle.Tools.MSBuildTask
         commandLine.AppendSwitch("\n/indentation-syntax");
       commandLine.AppendSwitchIfNotNull  ("\n/doc:",          this.DocumentationFile);
       def defines = base.DefineConstants
-        .Split(new char[]{';', ' ', '\r', '\n', '\t'}, StringSplitOptions.RemoveEmptyEntries);
+        .Split(array[';', ' ', '\r', '\n', '\t'], StringSplitOptions.RemoveEmptyEntries);
 
       commandLine.AppendSwitchUnquotedIfNotNull("\n/define:", String.Join(";", defines));
       commandLine.AppendSwitchIfNotNull  ("\n/win32res:",     base.Win32Resource);

--- a/tools/msbuild-task/MSBuildTask.n
+++ b/tools/msbuild-task/MSBuildTask.n
@@ -164,7 +164,7 @@ namespace Nemerle.Tools.MSBuildTask
       def defines = base.DefineConstants
         .Split(new char[]{';', ' ', '\r', '\n', '\t'}, StringSplitOptions.RemoveEmptyEntries);
 
-      commandLine.AppendSwitchUnquotedIfNotNull("\n/define:", String.Join(defines, ';'));
+      commandLine.AppendSwitchUnquotedIfNotNull("\n/define:", String.Join(";", defines));
       commandLine.AppendSwitchIfNotNull  ("\n/win32res:",     base.Win32Resource);
       commandLine.AppendSwitchIfNotNull  ("\n/platform:",     TargetPlatform);
 

--- a/tools/msbuild-task/MSBuildTask.n
+++ b/tools/msbuild-task/MSBuildTask.n
@@ -161,7 +161,10 @@ namespace Nemerle.Tools.MSBuildTask
       when (IndentationSyntax)
         commandLine.AppendSwitch("\n/indentation-syntax");
       commandLine.AppendSwitchIfNotNull  ("\n/doc:",          this.DocumentationFile);
-      commandLine.AppendSwitchUnquotedIfNotNull("\n/define:", base.DefineConstants);
+      def defines = base.DefineConstants
+        .Split(new char[]{';', ' ', '\r', '\n', '\t'}, StringSplitOptions.RemoveEmptyEntries);
+
+      commandLine.AppendSwitchUnquotedIfNotNull("\n/define:", String.Join(defines, ';'));
       commandLine.AppendSwitchIfNotNull  ("\n/win32res:",     base.Win32Resource);
       commandLine.AppendSwitchIfNotNull  ("\n/platform:",     TargetPlatform);
 


### PR DESCRIPTION
C# msbuild task parses DefineConstants project tag by differ way that Nemerle.

e.g. 
    <DefineConstants>A;B C</DefineConstants>
defines A, B and C constants, but Nemerle compiler fails because use /define:A;B C compiler switch. Where C parses as a source file.
