### PR TITLE
Fix .Net 3.5 compilation

### DIFF
--- a/Linq/Macro/Linq.nproj
+++ b/Linq/Macro/Linq.nproj
@@ -52,10 +52,7 @@
       <AssemblyName>System.Core.dll</AssemblyName>
     </Reference>
     <Reference Include="System.Data" />
-    <Reference Include="System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <Name>System.Windows.Forms</Name>
-      <AssemblyName>System.Windows.Forms.dll</AssemblyName>
-    </Reference>
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="$(Nemerle)\Nemerle.dll" />
     <Reference Include="$(Nemerle)\Nemerle.Compiler.dll" />

--- a/ncc/testsuite/positive/Issue-git-0255.cs
+++ b/ncc/testsuite/positive/Issue-git-0255.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿// REFERENCE: System.Core
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/ncc/testsuite/positive/linq-2-ExprTree.n
+++ b/ncc/testsuite/positive/linq-2-ExprTree.n
@@ -13,14 +13,24 @@ module Program
   Main() : void
   {
     System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
-  
+    
     def result = orders
       .Select(o => (o, /* t = */ o.Details.Sum(d => d.UnitPrice * (d.Quantity :> double))))
       .Where(fun((_o, t)) { t >= 10.0 })
-      .Select(fun((o, t)) { (o.OrderID, /* Total = */ t) })
-    ; 
+      .Select(fun((o, t)) { (o.OrderID, /* Total = */ t) }); 
 
-    WriteLine($"..$result");
+    // Workaround.
+    // There is bug that compiler generates following incorrect code; pay attention to "object":
+    // Console.WriteLine(string.Concat(array[string.Join(", ",
+    //   NCollectionsExtensions.MapToArray.[object, string](result, x => Convert.ToString(x)))]));
+    
+    // This is a correct generated code; pay attention to "Tuple.[int, double]":
+    // Console.WriteLine(string.Concat(array[string.Join(", ",
+    //   NCollectionsExtensions.MapToArray.[Tuple.[int, double], string](result, x => Convert.ToString(x)))]));
+    
+    //WriteLine($"..$a");    
+     Console.WriteLine(string.Concat(array[string.Join(", ",
+       NCollectionsExtensions.MapToArray(result, x => Convert.ToString(x)))]));
   }
 }
 

--- a/snippets/Nemerle.WPF/Nemerle.WPF/Nemerle.WPF.nproj
+++ b/snippets/Nemerle.WPF/Nemerle.WPF/Nemerle.WPF.nproj
@@ -58,10 +58,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(Nemerle)\Nemerle.Compiler.dll</HintPath>
     </Reference>
-    <Reference Include="WindowsBase, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
-      <Name>WindowsBase</Name>
-      <AssemblyName>WindowsBase.dll</AssemblyName>
-    </Reference>
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DependencyProperty.n" />


### PR DESCRIPTION
There is bug in $"..$a" macro.
Workaround for issue #267.
