### PR TITLE
Fix xbuild running for Mono

### DIFF
--- a/Nemerle.XBuild.Tasks.csproj
+++ b/Nemerle.XBuild.Tasks.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>Full</DebugType>
+    <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\Tasks</OutputPath>
     <DefineConstants>MONO;DEBUG;TRACE</DefineConstants>


### PR DESCRIPTION
In debug use "full" , not "Full"
