### PR TITLE
Make correct test both for Windows and Linux

### DIFF
--- a/ncc/testsuite/positive/Issue-git-0030.n
+++ b/ncc/testsuite/positive/Issue-git-0030.n
@@ -1,5 +1,5 @@
-﻿def x = '!';
-System.Console.WriteLine(if ($"\r\n$x" == "\r\n!") "OK" else "Fail");
+def x = '!';
+System.Console.WriteLine(if ($"\r\n$x" == System.Environment.NewLine + "!") "OK" else "Fail");
 /*
 BEGIN-OUTPUT
 OK


### PR DESCRIPTION
$"\r" gives System.Environment.NewLine which is not always same as "\r".
