### PR TITLE
Fix generic methods emit for value-type type-params

### DIFF
--- a/ncc/typing/StaticTyVar.n
+++ b/ncc/typing/StaticTyVar.n
@@ -331,7 +331,8 @@ namespace Nemerle.Compiler
         | _ => false
       }
 
-      def checkIsNullable(t) {
+      def checkIsNullable(t) 
+      {
         | FixedType.Class(ti, _) => ti.FullName != "System.ValueType" && t.CanBeNull
         | _                      => t.CanBeNull
       }

--- a/ncc/typing/StaticTyVar.n
+++ b/ncc/typing/StaticTyVar.n
@@ -331,12 +331,9 @@ namespace Nemerle.Compiler
         | _ => false
       }
 
-      def check_is_nullable(t) {
-        match(t)
-        {
-          | FixedType.Class(ti, _) => ti.FullName != "System.ValueType" && t.CanBeNull
-          | _                      => t.CanBeNull;
-        }
+      def checkIsNullable(t) {
+        | FixedType.Class(ti, _) => ti.FullName != "System.ValueType" && t.CanBeNull
+        | _                      => t.CanBeNull
       }
 
       def check_constraints(t, c) 
@@ -352,7 +349,7 @@ namespace Nemerle.Compiler
       mutable ok = true;
 
       when (SpecialConstraints %&& GenericParameterAttributes.NotNullableValueTypeConstraint
-            && check_constraints(t, check_is_nullable))
+            && check_constraints(t, checkIsNullable))
       {
         // cs453
         when (needMessage)

--- a/ncc/typing/StaticTyVar.n
+++ b/ncc/typing/StaticTyVar.n
@@ -331,6 +331,14 @@ namespace Nemerle.Compiler
         | _ => false
       }
 
+      def check_is_nullable(t) {
+        match(t)
+        {
+          | FixedType.Class(ti, _) => ti.FullName != "System.ValueType" && t.CanBeNull
+          | _                      => t.CanBeNull;
+        }
+      }
+
       def check_constraints(t, c) 
       {
         !match(t)
@@ -344,7 +352,7 @@ namespace Nemerle.Compiler
       mutable ok = true;
 
       when (SpecialConstraints %&& GenericParameterAttributes.NotNullableValueTypeConstraint
-            && check_constraints(t, c => c.CanBeNull))
+            && check_constraints(t, check_is_nullable))
       {
         // cs453
         when (needMessage)

--- a/ncc/typing/StaticTyVar.n
+++ b/ncc/typing/StaticTyVar.n
@@ -333,7 +333,7 @@ namespace Nemerle.Compiler
 
       def checkIsNullable(t) 
       {
-        | FixedType.Class(ti, _) => ti.FullName != "System.ValueType" && t.CanBeNull
+        | FixedType.Class(ti, _) => !ti.Equals(InternalType.ValueType_tc) && t.CanBeNull
         | _                      => t.CanBeNull
       }
 

--- a/ncc/typing/TyVarEnv.n
+++ b/ncc/typing/TyVarEnv.n
@@ -554,7 +554,11 @@ namespace Nemerle.Compiler
             match (c.ty)
             {
               | <[ @class ]>  when c.IsSpecial => special |= GenericParameterAttributes.ReferenceTypeConstraint;
-              | <[ @struct ]> when c.IsSpecial => { special |= (GenericParameterAttributes.NotNullableValueTypeConstraint | GenericParameterAttributes.DefaultConstructorConstraint); def ty = tenv.BindFixedType (env, currentType, <[ System.ValueType ]>, check_parms = false); subtype ::= ty; }
+              | <[ @struct ]> when c.IsSpecial =>
+                special |= GenericParameterAttributes.NotNullableValueTypeConstraint;
+                special |= GenericParameterAttributes.DefaultConstructorConstraint;
+                def ty = tenv.BindFixedType (env, currentType, <[ System.ValueType ]>, check_parms = false);
+                subtype ::= ty; 
               | <[ @new ]>    when c.IsSpecial => special |= GenericParameterAttributes.DefaultConstructorConstraint;
               | <[ @+ ]>      when c.IsSpecial => special |= GenericParameterAttributes.Covariant;
               | <[ @- ]>      when c.IsSpecial => special |= GenericParameterAttributes.Contravariant;

--- a/ncc/typing/TyVarEnv.n
+++ b/ncc/typing/TyVarEnv.n
@@ -554,7 +554,7 @@ namespace Nemerle.Compiler
             match (c.ty)
             {
               | <[ @class ]>  when c.IsSpecial => special |= GenericParameterAttributes.ReferenceTypeConstraint;
-              | <[ @struct ]> when c.IsSpecial => special |= (GenericParameterAttributes.NotNullableValueTypeConstraint | GenericParameterAttributes.DefaultConstructorConstraint);
+              | <[ @struct ]> when c.IsSpecial => { special |= (GenericParameterAttributes.NotNullableValueTypeConstraint | GenericParameterAttributes.DefaultConstructorConstraint); def ty = tenv.BindFixedType (env, currentType, <[ System.ValueType ]>, check_parms = false); subtype ::= ty; }
               | <[ @new ]>    when c.IsSpecial => special |= GenericParameterAttributes.DefaultConstructorConstraint;
               | <[ @+ ]>      when c.IsSpecial => special |= GenericParameterAttributes.Covariant;
               | <[ @- ]>      when c.IsSpecial => special |= GenericParameterAttributes.Contravariant;


### PR DESCRIPTION
This patch fixes emition of generic methods which have type parameters with 'struct' constrain. Old implementation didn't emit 'System.ValueType' constrain.

Here is an example. This generic method signature got from C# code:

   .method public static hidebysig 
           default valuetype [mscorlib]System.Nullable`1<!!T> Fail<valuetype .ctor (class [mscorlib]System.ValueType) T> ()  cil managed 

...and this -- from Nemerle:

   .method public static hidebysig 
           default valuetype [mscorlib]System.Nullable`1<!!T> Fail<valuetype .ctor T> ()  cil managed 

See the difference is <valuetype .ctor (class [mscorlib]System.ValueType) T> vs <valuetype .ctor T>.
