### PR TITLE
Added $(NemerleVersion) to $(Nemerle) path in ComputationExpression.nproj

### DIFF
--- a/snippets/ComputationExpressions/ComputationExpressions/ComputationExpressions.nproj
+++ b/snippets/ComputationExpressions/ComputationExpressions/ComputationExpressions.nproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="3.5" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <NoStdLib>true</NoStdLib>
-    <Nemerle Condition=" '$(Nemerle)' == '' ">$(ProgramFiles)\Nemerle</Nemerle>
+    <Nemerle Condition=" '$(Nemerle)' == '' ">$(ProgramFiles)\$(NemerleVersion)\Nemerle</Nemerle>
     <Name>ComputationExpressions</Name>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
ComputationExpression project wasn't being rebuilt against updated Nemerle binaries.
