### PR TITLE
Fixed visual studio crash, when right clicking on folder in ASP.NET MVC 4 project

### DIFF
--- a/snippets/VS2010/Nemerle.VisualStudio/Nemerle.VisualStudio.csproj
+++ b/snippets/VS2010/Nemerle.VisualStudio/Nemerle.VisualStudio.csproj
@@ -183,6 +183,7 @@
     <Compile Include="ProjectBaseModifications\SettingsPage.cs" />
     <Compile Include="Project\CopyToOutputDirectory.cs" />
     <Compile Include="Project\GotoInfoLibraryNode.cs" />
+    <Compile Include="Project\NemerleOAFolderItem.cs" />
     <Compile Include="Project\ProjectUpgradeHelper.cs" />
     <Compile Include="Project\ScopeNode.cs" />
     <Compile Include="Project\HierarchyListener.cs" />

--- a/snippets/VS2010/Nemerle.VisualStudio/Project/NemerleFolderNode.cs
+++ b/snippets/VS2010/Nemerle.VisualStudio/Project/NemerleFolderNode.cs
@@ -314,6 +314,20 @@ namespace Nemerle.VisualStudio.Project
 			return base.ExecCommandOnNode(cmdGroup, cmd, cmdexecopt, pvaIn, pvaOut);
 		}
 
+        /// <summary>
+		/// Get the automation object for the FolderNode
+		/// </summary>
+		/// <returns>An instance of the NemerleOAFolderItem type if succeeded</returns>
+		public override object GetAutomationObject()
+		{
+			if(this.ProjectMgr == null || this.ProjectMgr.IsClosed)
+			{
+				return null;
+			}
+
+			return new NemerleOAFolderItem(this.ProjectMgr.GetAutomationObject() as Microsoft.VisualStudio.Project.Automation.OAProject, this);
+		}
+
 		#endregion
 
 		#region Methods

--- a/snippets/VS2010/Nemerle.VisualStudio/Project/NemerleOAFolderItem.cs
+++ b/snippets/VS2010/Nemerle.VisualStudio/Project/NemerleOAFolderItem.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics;
+using EnvDTE;
+using Microsoft.VisualStudio.Project;
+using Microsoft.VisualStudio.Project.Automation;
+
+namespace Nemerle.VisualStudio.Project
+{
+    public class NemerleOAFolderItem : OAFolderItem
+    {
+        public NemerleOAFolderItem(OAProject project, FolderNode node) : base(project, node)
+        {}
+
+        public override ProjectItems Collection
+        {
+            get
+            {
+                Debug.Assert(Node.Parent != null, string.Format("Failed to get the parent node of '{0}'", Node.Caption));
+                return new OAProjectItems(Project, Node.Parent);
+            }
+        }
+
+        public override ProjectItems ProjectItems
+        {
+            get
+            {
+                return new OAProjectItems(Project, Node);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Previous implementation of OAFolderItem contained a bug, which caused StackOverflowException when some code tried to access hierarchy from bottom to top. There is a proper explanation here:
http://www.mztools.com/articles/2007/mz2007031.aspx

In our case Microsoft.VisualStudio.Web.Mvc.Extensibility.ProjectFolder.RelativePath caused SOE because it was accessing Node.Collection.Parent recursively. And this Parent was always the same folder i.e. Node.Collection.Parent.Collection.Parent.Collection...

The problem is: I'm still not sure about correct implementation of Collection and ProjectItems properties, because even though original implementation causes a crash, it is widely used in other projects I found in google.

I tested new implementation a little, and seems like ProjectFolder.RelativePath returns correct path now, regardless of hierarchy used.
