### PR TITLE
Attempt to fix Issue #379

### DIFF
--- a/macros/assertions.n
+++ b/macros/assertions.n
@@ -261,7 +261,7 @@ namespace Nemerle.Assertions
           m.Body = newBody;
         }
         ty.Define ( <[ decl:
-          public mutable _N_invariant_lock : bool;
+          public mutable _N_invariant_affinity : int = -1;
         ]> );
         ty.Define ( <[ decl:
           public virtual _N_invariant () : void
@@ -288,10 +288,12 @@ namespace Nemerle.Assertions
     <[ 
       def e = $exposed;
       lock (e) {
-        when (e._N_invariant_lock)
-          throw System.Exception ();
+        def currentThreadId = System.Threading.Thread.CurrentThread.ManagedThreadId;
+        
+        when (e._N_invariant_affinity != -1 && e._N_invariant_affinity != currentThreadId)
+          throw System.Exception($"Invariant lock has already been taken from another thread $currentThreadId");
           
-          e._N_invariant_lock = true
+        e._N_invariant_affinity = currentThreadId
       }
       mutable need_to_check = false;
 
@@ -311,7 +313,7 @@ namespace Nemerle.Assertions
       {
         lock (e) 
         {
-          e._N_invariant_lock = false;
+          e._N_invariant_affinity = -1;
           when (need_to_check)
             e._N_invariant ()        
         }


### PR DESCRIPTION
Invariant now allows re-entrance from same thread, such as:

``` nemerle
public class Example
invariant x >= 0 && x <= 10
{
    mutable x : int = 0;

    public test2() : void
    {
        test()
    }

    public test() : void
    {
        x = 5;
    }
}

Example().test2() 
```
