### PR TITLE
Pull: use 4 as default for min switch size for variants. Closes #180

### DIFF
--- a/ncc/CompilationOptions.n
+++ b/ncc/CompilationOptions.n
@@ -952,7 +952,7 @@ namespace Nemerle.Compiler
 
     public Clear() : void
     {
-      min_switch_size_for_variants = 12;
+      min_switch_size_for_variants = 4;
       min_switch_size_for_ordinals = 4;
     }
   }


### PR DESCRIPTION
```
use 4 as default for min switch size for variants. Closes #180
```
