### PR TITLE
Operator()

### DIFF
--- a/ncc/parsing/ParseTree.n
+++ b/ncc/parsing/ParseTree.n
@@ -1081,7 +1081,7 @@ namespace Nemerle.Compiler.Parsetree
                   // Create generic args
                   mutable argsExpr = [];
                   for (mutable i = 0; i < argsNum; i++)
-                    argsExpr ::= name(args[posArg - argsNum + i]);
+                    argsExpr ::= FromQualifiedIdentifier(manager, args[posArg - argsNum + i]);
                   
                   <[ $ex.[..$(argsExpr.Rev())] ]>
                 }

--- a/ncc/parsing/ParseTree.n
+++ b/ncc/parsing/ParseTree.n
@@ -30,6 +30,8 @@ using Nemerle.Compiler;
 using Nemerle.Utility;
 
 using System.Diagnostics;
+using SCG = System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 using T = Nemerle.Compiler.Typedtree;
 
@@ -1013,6 +1015,93 @@ namespace Nemerle.Compiler.Parsetree
         expr
       }
     }
+    
+    /// <summary>
+    /// Transforms system type identifier with generic arguments to the parse-tree expression.
+    /// Number of elemnts in args must match number of generic parameters in the systemType.
+    /// </summary>
+    /// <example>
+    /// "NS.A`2+B`1", ["X", "Y", "Z"] ==> <[ NS.A.[X, Y].B.[Z] ]>
+    /// </example>
+    public static FromSystemType(manager : ManagerClass, systemType : string, args : list[string]) : PExpr
+    {
+      if (string.IsNullOrEmpty (systemType)) <[]>
+      else
+      {
+        // Split according to generic arguments number
+        def parts = _genericArgs.Split(systemType.Replace("+", "."));
+        if (parts.Length == 1)
+          // No generic, convert as usual
+          FromQualifiedIdentifier(manager, systemType)
+        else
+        {
+          def name(n)
+          {
+            <[ $(Name(n, manager.MacroColors.UseColor, manager.MacroColors.UseContext) : name) ]>
+          }
+          def createExpr(parts, pos, args, posArg, expr)
+          {
+            if (pos >= 0)
+            {
+              def part = parts[pos];
+              if (part.Length != 0)
+              {
+                // even - Member
+                // odd - GenericSpecifier                
+                if (pos % 2 == 0)
+                {                  
+                  def split = part.Split('.');
+                  
+                  // Create expression
+                  mutable ex = createExpr(parts, pos - 1, args, posArg, expr);
+                  
+                  // Add first member if can and need
+                  ex =
+                    if (ex is <[]>)
+                      name(split[0])
+                    else
+                    if (split[0].Length != 0)
+                      <[ $ex.$(name(split[0])) ]>
+                    else
+                      ex;
+                  
+                  // Add other members if exist
+                  for (mutable i = 1; i < split.Length; i++)
+                    ex = <[ $ex.$(name(split[i])) ]>;
+                  
+                  ex
+                }
+                else
+                {
+                  def argsNum = int.Parse(parts[pos]);
+                  
+                  // Create expression
+                  mutable ex = createExpr(parts, pos - 1, args, posArg - argsNum, expr);
+                  
+                  // Create generic args
+                  mutable argsExpr = [];
+                  for (mutable i = 0; i < argsNum; i++)
+                    argsExpr ::= name(args[posArg - argsNum + i]);
+                  
+                  <[ $ex.[..$(argsExpr.Rev())] ]>
+                }
+              }
+              else
+                // Skip empty sequence
+                createExpr(parts, pos - 1, args, posArg, expr)
+            }
+            else
+              expr
+          }
+          
+          def argsList = SCG.List(args);
+          def ret = createExpr(parts, parts.Length - 1, argsList, argsList.Count, <[]>);
+          ret
+        }
+      }
+    }
+    
+    private static _genericArgs : Regex = Regex(@"`(\d)");
   }
 
   [Record]

--- a/ncc/parsing/ParseTree.n
+++ b/ncc/parsing/ParseTree.n
@@ -1028,77 +1028,79 @@ namespace Nemerle.Compiler.Parsetree
     /// <example>
     /// "NS.A`2+B`1", ["X", "Y", "Z"] ==> <[ NS.A.[X, Y].B.[Z] ]>
     /// </example>
-    public static FromSystemType(manager : ManagerClass, systemType : string, args : list[string]) : PExpr
+    public static FromTypeVar(manager : ManagerClass, type : TypeVar) : PExpr
     {
-      if (string.IsNullOrEmpty (systemType)) <[]>
-      else
+      match (type.Hint)
       {
-        // Split according to generic arguments number
-        def parts = _genericArgs.Split(systemType.Replace("+", "."));
-        if (parts.Length == 1)
-          // No generic, convert as usual
-          FromQualifiedIdentifier(manager, systemType)
-        else
-        { 
-          def createExpr(parts, pos, args, posArg, expr)
-          {
-            if (pos >= 0)
+        | Some(FixedType.Class(tycon, args)) =>
+          // Split according to generic arguments number
+          def fullName = tycon.SystemType.FullName;
+          def parts = _genericArgs.Split(fullName.Replace("+", "."));
+          if (parts.Length == 1)
+            // No generic, convert as usual
+            FromQualifiedIdentifier(manager, fullName)
+          else
+          { 
+            def createExpr(parts, pos, args, posArg, expr)
             {
-              def part = parts[pos];
-              if (part.Length != 0)
+              if (pos >= 0)
               {
-                // even - Member
-                // odd - GenericSpecifier                
-                if (pos % 2 == 0)
-                {                  
-                  def split = part.Split('.');
+                def part = parts[pos];
+                if (part.Length != 0)
+                {
+                  // even - Member
+                  // odd - GenericSpecifier                
+                  if (pos % 2 == 0)
+                  {
+                    def split = part.Split('.');
                   
-                  // Create expression
-                  mutable ex = createExpr(parts, pos - 1, args, posArg, expr);
+                    // Create expression
+                    mutable ex = createExpr(parts, pos - 1, args, posArg, expr);
                   
-                  // Add first member if can and need
-                  ex =
-                    if (ex is <[]>)
-                      MakeName(manager, split[0])
-                    else
-                    if (split[0].Length != 0)
-                      <[ $ex.$(MakeName(manager, split[0])) ]>
-                    else
-                      ex;
+                    // Add first member if can and need
+                    ex =
+                      if (ex is <[]>)
+                        MakeName(manager, split[0])
+                      else
+                      if (split[0].Length != 0)
+                        <[ $ex.$(MakeName(manager, split[0])) ]>
+                      else
+                        ex;
                   
-                  // Add other members if exist
-                  for (mutable i = 1; i < split.Length; i++)
-                    ex = <[ $ex.$(MakeName(manager, split[i])) ]>;
+                    // Add other members if exist
+                    for (mutable i = 1; i < split.Length; i++)
+                      ex = <[ $ex.$(MakeName(manager, split[i])) ]>;
                   
-                  ex
+                    ex
+                  }
+                  else
+                  {
+                    def argsNum = int.Parse(parts[pos]);
+                  
+                    // Create expression
+                    mutable ex = createExpr(parts, pos - 1, args, posArg - argsNum, expr);
+                  
+                    // Create generic args
+                    mutable argsExpr = [];
+                    for (mutable i = 0; i < argsNum; i++)
+                      argsExpr ::= FromTypeVar(manager, args[posArg - argsNum + i]);
+                  
+                    <[ $ex.[..$(argsExpr.Rev())] ]>
+                  }
                 }
                 else
-                {
-                  def argsNum = int.Parse(parts[pos]);
-                  
-                  // Create expression
-                  mutable ex = createExpr(parts, pos - 1, args, posArg - argsNum, expr);
-                  
-                  // Create generic args
-                  mutable argsExpr = [];
-                  for (mutable i = 0; i < argsNum; i++)
-                    argsExpr ::= FromQualifiedIdentifier(manager, args[posArg - argsNum + i]);
-                  
-                  <[ $ex.[..$(argsExpr.Rev())] ]>
-                }
+                  // Skip empty sequence
+                  createExpr(parts, pos - 1, args, posArg, expr)
               }
               else
-                // Skip empty sequence
-                createExpr(parts, pos - 1, args, posArg, expr)
+                expr
             }
-            else
-              expr
-          }
           
-          def argsList = SCG.List(args);
-          def ret = createExpr(parts, parts.Length - 1, argsList, argsList.Count, <[]>);
-          ret
-        }
+            def argsList = SCG.List(args);
+            def ret = createExpr(parts, parts.Length - 1, argsList, argsList.Count, <[]>);
+            ret
+          }
+        | _ => <[]>
       }
     }
     

--- a/ncc/parsing/ParseTree.n
+++ b/ncc/parsing/ParseTree.n
@@ -1003,15 +1003,20 @@ namespace Nemerle.Compiler.Parsetree
 
     public override ToString () : string { PrettyPrint.SprintExpr (None (), this); }
 
+    private static MakeName(manager : ManagerClass, name : string) : PExpr.Ref
+    {
+      <[ $(Name(name, manager.MacroColors.UseColor, manager.MacroColors.UseContext) : name) ]>
+    }
+    
     // transforms dot-separated identifier to the parse-tree expression
     public static FromQualifiedIdentifier (manager : ManagerClass, qid : string) : PExpr
     {
       if (string.IsNullOrEmpty (qid)) null
       else {
         def split = qid.Split ('.');
-        mutable expr = <[ $(Name (split [0], manager.MacroColors.UseColor, manager.MacroColors.UseContext) : name) ]>;
+        mutable expr = MakeName(manager, split[0]);
         for (mutable i = 1; i < split.Length; i++)
-          expr = <[ $expr . $(Name (split [i], manager.MacroColors.UseColor, manager.MacroColors.UseContext) : name) ]>;
+          expr = <[ $expr . $(MakeName(manager, split[i])) ]>;
         expr
       }
     }
@@ -1034,11 +1039,7 @@ namespace Nemerle.Compiler.Parsetree
           // No generic, convert as usual
           FromQualifiedIdentifier(manager, systemType)
         else
-        {
-          def name(n)
-          {
-            <[ $(Name(n, manager.MacroColors.UseColor, manager.MacroColors.UseContext) : name) ]>
-          }
+        { 
           def createExpr(parts, pos, args, posArg, expr)
           {
             if (pos >= 0)
@@ -1058,16 +1059,16 @@ namespace Nemerle.Compiler.Parsetree
                   // Add first member if can and need
                   ex =
                     if (ex is <[]>)
-                      name(split[0])
+                      MakeName(manager, split[0])
                     else
                     if (split[0].Length != 0)
-                      <[ $ex.$(name(split[0])) ]>
+                      <[ $ex.$(MakeName(manager, split[0])) ]>
                     else
                       ex;
                   
                   // Add other members if exist
                   for (mutable i = 1; i < split.Length; i++)
-                    ex = <[ $ex.$(name(split[i])) ]>;
+                    ex = <[ $ex.$(MakeName(manager, split[i])) ]>;
                   
                   ex
                 }

--- a/ncc/testsuite/positive/operator().n
+++ b/ncc/testsuite/positive/operator().n
@@ -44,6 +44,15 @@ namespace Test
       // Generic, nested class
       def bc = X.Y.B.[System.String].C.[double]();
       bc("e");
+      
+      // TODO: Generic in generic
+      // def bcg = X.Y.B.[X.Y.B.[System.Int32]].C.[double]();
+      // bcg(10)
+      // B.@()(e : System.Int32)
+      
+      // TODO: Expression
+      // (if(true) X.Y.A() else X.Y.A())(11)
+      // A.@(11 : int)
     }
   }
 }

--- a/ncc/testsuite/positive/operator().n
+++ b/ncc/testsuite/positive/operator().n
@@ -61,7 +61,7 @@ BEGIN-OUTPUT
 A.@()(1 : int)
 A.@()(1 : int)
 A.@()(x : string)
-B.C@()(e : System.String)
+B.C.@()(e : System.String)
 B.C.@()(X.Y.B`1[System.Int32] : X.Y.B`1[System.Int32])
 A.@()(11 : int)
 B.C.@()(X.Y.B`1[System.String] : X.Y.B`1[System.String])

--- a/ncc/testsuite/positive/operator().n
+++ b/ncc/testsuite/positive/operator().n
@@ -1,0 +1,58 @@
+using System.Console;
+
+namespace X.Y
+{
+  class A
+  {
+    public static @()(_a : A, x: int) : void
+    {
+      WriteLine("A.@({0} : int)", x);
+    }
+ 
+    public static @()(_a : A, x: string) : void
+    {
+      WriteLine("A.@({0} : string)", x);
+    }
+  }
+
+  class B[T]
+  {
+    public class C[TT]
+    {
+      public static @()(_c : C[TT], x : T) : void
+      {
+        WriteLine("B.@({0} : {1})", x, typeof(T).ToString());
+      }
+    }
+  }
+}
+
+namespace Test
+{
+  module Program
+  {
+    Main() : void
+    { 
+      def a = X.Y.A();
+      // Call directly
+      X.Y.A.@()(a, 1);
+
+      // using @()
+      a(1);
+      a("x");
+
+      // Generic, nested class
+      def bc = X.Y.B.[System.String].C.[double]();
+      bc("e");
+    }
+  }
+}
+
+/*
+BEGIN-OUTPUT
+A.@()(1 : int)
+A.@()(1 : int)
+A.@()(x : string)
+B.@()(e : System.String)
+END-OUTPUT
+*/

--- a/ncc/testsuite/positive/operator().n
+++ b/ncc/testsuite/positive/operator().n
@@ -6,12 +6,12 @@ namespace X.Y
   {
     public static @()(_a : A, x: int) : void
     {
-      WriteLine("A.@({0} : int)", x);
+      WriteLine("A.@()({0} : int)", x);
     }
  
     public static @()(_a : A, x: string) : void
     {
-      WriteLine("A.@({0} : string)", x);
+      WriteLine("A.@()({0} : string)", x);
     }
   }
 
@@ -21,7 +21,7 @@ namespace X.Y
     {
       public static @()(_c : C[TT], x : T) : void
       {
-        WriteLine("B.@({0} : {1})", x, typeof(T).ToString());
+        WriteLine("B.C.@()({0} : {1})", x, typeof(T).ToString());
       }
     }
   }
@@ -50,9 +50,10 @@ namespace Test
       // bcg(10)
       // B.@()(e : System.Int32)
       
-      // TODO: Expression
-      // (if(true) X.Y.A() else X.Y.A())(11)
-      // A.@(11 : int)
+      (if(true) X.Y.A() else X.Y.A())(11)
+      
+      //(if(true) X.Y.B.[X.Y.B.[string]].C() else X.Y.B.[X.Y.B.[string]].C())("x");
+      // B.C@()(x : System.String)
     }
   }
 }
@@ -62,6 +63,7 @@ BEGIN-OUTPUT
 A.@()(1 : int)
 A.@()(1 : int)
 A.@()(x : string)
-B.@()(e : System.String)
+B.C@()(e : System.String)
+A.@()(11 : int)
 END-OUTPUT
 */

--- a/ncc/testsuite/positive/operator().n
+++ b/ncc/testsuite/positive/operator().n
@@ -45,15 +45,13 @@ namespace Test
       def bc = X.Y.B.[System.String].C.[double]();
       bc("e");
       
-      // TODO: Generic in generic
-      // def bcg = X.Y.B.[X.Y.B.[System.Int32]].C.[double]();
-      // bcg(10)
-      // B.@()(e : System.Int32)
+      def bcg = X.Y.B.[X.Y.B.[System.Int32]].C.[double]();
+      bcg(X.Y.B.[System.Int32]());
       
-      (if(true) X.Y.A() else X.Y.A())(11)
+      (if(true) X.Y.A() else X.Y.A())(11);
       
-      //(if(true) X.Y.B.[X.Y.B.[string]].C() else X.Y.B.[X.Y.B.[string]].C())("x");
-      // B.C@()(x : System.String)
+      (if(true) X.Y.B.[X.Y.B.[string]].C.[char]() else X.Y.B.[X.Y.B.[string]].C.[char]())
+        (X.Y.B.[string]());
     }
   }
 }
@@ -64,6 +62,8 @@ A.@()(1 : int)
 A.@()(1 : int)
 A.@()(x : string)
 B.C@()(e : System.String)
+B.C.@()(X.Y.B`1[System.Int32] : X.Y.B`1[System.Int32])
 A.@()(11 : int)
+B.C.@()(X.Y.B`1[System.String] : X.Y.B`1[System.String])
 END-OUTPUT
 */

--- a/ncc/typing/MType.n
+++ b/ncc/typing/MType.n
@@ -26,6 +26,11 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+
 using Nemerle.Compiler.SolverMacros;
 using Nemerle.Collections;
 using Nemerle.Imperative;
@@ -476,6 +481,8 @@ namespace Nemerle.Compiler
     mutable _recursionLevel = 0 : byte;
 #endif // DEBUG
 
+    private _genericArgs : Regex = Regex(@"`(\d)");
+
     public override ToString () : string
     {
 #if DEBUG
@@ -518,15 +525,41 @@ namespace Nemerle.Compiler
             }
 
           | Class (tc, args) =>
-            def name = match (tc.NamespaceNode.FullName)
+            def normalizeName(name)
             {
-              | ["Nemerle", "Core", "list"]
-              | ["Nemerle", "Core", "list", "Nil"]
-              | ["Nemerle", "Core", "list", "Cons"] => "list"
-              | "Nemerle" :: "Core" :: name | name  => $<#..$(name; ".")#>
+              name.Replace('+', '.')
+                  .Replace("Nemerle.Core.list", "")
+                  .Replace("Nemerle.Core.list.Nil", "list")
+                  .Replace("Nemerle.Core.list.Cons", "list")
+                  .Replace("Nemerle.Core.", "")
             }
-
-            $<#$name[..$args]#>
+            
+            def genericArgs = List(args);
+            def fullName = normalizeName(tc.SystemType.FullName);
+                
+            // Split according to generic arguments number
+            def parts = _genericArgs.Split(fullName, int.MaxValue);
+    
+            def sb = StringBuilder();
+            mutable posArg;
+            for (mutable i = 0; i < parts.Length - 1; i += 2)
+            {
+              def argsNum = int.Parse(parts[i + 1]);
+               
+              _ = sb.Append(parts[i]);
+              _ = sb.Append("[");
+              repeat (argsNum)
+              {
+                _ = sb.Append(genericArgs[posArg]);
+                _ = sb.Append(",");
+                posArg++;
+              }
+              // Remove last comma
+              _ = sb.Remove(sb.Length - 1, 1);
+              _ = sb.Append("]");
+            }
+            
+            sb.ToString()
 
           | StaticTypeVarRef (s) => s.ToString ()
           | Fun (t1, t2) => $ "$t1 -> $t2"

--- a/ncc/typing/MType.n
+++ b/ncc/typing/MType.n
@@ -26,11 +26,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Text.RegularExpressions;
-
 using Nemerle.Compiler.SolverMacros;
 using Nemerle.Collections;
 using Nemerle.Imperative;
@@ -481,8 +476,6 @@ namespace Nemerle.Compiler
     mutable _recursionLevel = 0 : byte;
 #endif // DEBUG
 
-    private _genericArgs : Regex = Regex(@"`(\d)");
-
     public override ToString () : string
     {
 #if DEBUG
@@ -525,41 +518,15 @@ namespace Nemerle.Compiler
             }
 
           | Class (tc, args) =>
-            def normalizeName(name)
+            def name = match (tc.NamespaceNode.FullName)
             {
-              name.Replace('+', '.')
-                  .Replace("Nemerle.Core.list", "")
-                  .Replace("Nemerle.Core.list.Nil", "list")
-                  .Replace("Nemerle.Core.list.Cons", "list")
-                  .Replace("Nemerle.Core.", "")
+              | ["Nemerle", "Core", "list"]
+              | ["Nemerle", "Core", "list", "Nil"]
+              | ["Nemerle", "Core", "list", "Cons"] => "list"
+              | "Nemerle" :: "Core" :: name | name  => $<#..$(name; ".")#>
             }
-            
-            def genericArgs = List(args);
-            def fullName = normalizeName(tc.SystemType.FullName);
-                
-            // Split according to generic arguments number
-            def parts = _genericArgs.Split(fullName, int.MaxValue);
-    
-            def sb = StringBuilder();
-            mutable posArg;
-            for (mutable i = 0; i < parts.Length - 1; i += 2)
-            {
-              def argsNum = int.Parse(parts[i + 1]);
-               
-              _ = sb.Append(parts[i]);
-              _ = sb.Append("[");
-              repeat (argsNum)
-              {
-                _ = sb.Append(genericArgs[posArg]);
-                _ = sb.Append(",");
-                posArg++;
-              }
-              // Remove last comma
-              _ = sb.Remove(sb.Length - 1, 1);
-              _ = sb.Append("]");
-            }
-            
-            sb.ToString()
+
+            $<#$name[..$args]#>
 
           | StaticTypeVarRef (s) => s.ToString ()
           | Fun (t1, t2) => $ "$t1 -> $t2"

--- a/ncc/typing/Typer-CallTyper.n
+++ b/ncc/typing/Typer-CallTyper.n
@@ -147,45 +147,15 @@ namespace Nemerle.Compiler
             //Message.Debug ($"formals_types: $formals_types");
           
           | _ when Option.IsSome (fun_ty.Hint) =>
-            def error()
-            {
-              when (messenger.NeedMessage)
-                match (function_called)
-                {
-                  | TExpr.PropertyMember
-                  | TExpr.StaticPropertyRef =>
-                    Message.Hint ("attempting to call a property, please use assignment to set it");
-                  | _ => {}
-                }
-              
-              ReportError (messenger, $"the value called ($function_called) has non-functional type $fun_ty")
-            }
-            
-            match(fun_ty.FixedValue)
-            {
-              | c is Nemerle.Compiler.FixedType.Class =>
-                match (c.tycon.LookupMember("()"))
-                {
-                  | [] => error();
-                  | callOps =>
-                    def res = callOps.Find(m => 
-                      match (m)
-                      {
-                        | method is Nemerle.Compiler.MethodBuilder =>
-                          method.Header.Parameters.Length == argument_number
-                        | _ => false
-                      });
-                    
-                    match (res)
-                    {
-                      | Some(method is MethodBuilder) =>                        
-                        result_type = method.Header.ReturnType;
-                        formals_types = method.Header.Parameters.Map(p => p.ty);
-                      | _ => error();
-                    }
-                }
-              | _ => error();
-            }
+            when (messenger.NeedMessage)
+              match (function_called) {
+                | TExpr.PropertyMember
+                | TExpr.StaticPropertyRef =>
+                  Message.Hint ("attempting to call a property, please use assignment to set it");
+                | _ => {}
+              }
+            ReportError (messenger, $"the value called ($function_called) has non-functional type $fun_ty")          
+          
           | _ =>
             formals_types =
               NList.RevMap (call_parms, fun (_) { typer.FreshTypeVar () });

--- a/ncc/typing/Typer.n
+++ b/ncc/typing/Typer.n
@@ -1583,7 +1583,6 @@ namespace Nemerle.Compiler
           throw CompilationAbortedException($"typing method body of $(GetTopTyper ().current_fun)");
 
       def (pexpr, debugLocation) = GetDebugLocation(expression);
-//when(expression.ToString() == "b" /*|| expression.ToString() == "a"*/) assert2(false);
       ////when (Debugger.IsAttached && this.current_method_builder != null && this.current_method_builder.Header.Name == "Main")
       ////  assert2(true);
 
@@ -3863,7 +3862,7 @@ namespace Nemerle.Compiler
       }
 
       mutable parameters = parms.Map(compile_parm);
-      //when(pfnc.ToString() == "b" || pfnc.ToString() == "a") System.Diagnostics.Debugger.Break();
+      
       def fnc =
         match (pfnc, parameters)
         {
@@ -3994,9 +3993,57 @@ namespace Nemerle.Compiler
             fnc
 
           | fnc =>
-            def res = TryTypeCall (fnc, parameters, expected,
-                                   var_args = false,
-                                   final = !Manager.IsSpeculativeTyping);
+            def typeCall()
+            {
+              TryTypeCall(fnc,
+                          parameters,
+                          expected,
+                          var_args = false,
+                          final = !Manager.IsSpeculativeTyping);
+            }
+                      
+            def res = 
+              match (fnc.ty.FixedValue, pfnc)
+              {
+                // If fnc is typed to type, we need to check for @() operator.
+                | (FixedType.Class(tc, args), local is PExpr.Ref) =>
+                  def opCall = tc.LookupMember("()");
+                  match (opCall)
+                  {
+                    | [] => typeCall()
+                    | _ =>
+                      match (args)
+                      {
+                        | [] => 
+                          // Convert a(params) to A.@()(params)
+                      
+                          // Create recursive Member(Member(Ref(Name(), Ref(Name)...)
+                          def refName(e)
+                          {
+                            PExpr.Ref(PT.Name.NameInCurrentColor(e, local.name.context))
+                          }
+                          def parseType(l)
+                          {
+                            | [hd]     => refName(hd)
+                            | hd :: tl => PExpr.Member(parseType(tl), refName(hd))
+                            | _ => Util.ice("Type is empty")
+                          }
+                      
+                          def fullName = tc.FullName;
+                          def type = parseType(fullName.Split('.').NToList().Rev());
+                      
+                          def newExpr = 
+                            PExpr.Call(
+                              PExpr.Member(type, PT.Splicable.Name(PT.Name("()"))),
+                              local :: parms);
+                        
+                          TypeExpr(newExpr);
+                        | _ =>
+                          typeCall()
+                      }
+                  }
+                | _ => typeCall()
+             };
             res
         };
 

--- a/ncc/typing/Typer.n
+++ b/ncc/typing/Typer.n
@@ -4015,7 +4015,7 @@ namespace Nemerle.Compiler
                       def type =
                         PExpr.FromSystemType(
                           Manager,
-                          tc.SystemType.ToString(),
+                          tc.SystemType.FullName,
                           args.Map(a => a.TypeInfo.ToString()));
                       def newExpr = 
                         PExpr.Call(

--- a/ncc/typing/Typer.n
+++ b/ncc/typing/Typer.n
@@ -4000,7 +4000,7 @@ namespace Nemerle.Compiler
                           var_args = false,
                           final = !Manager.IsSpeculativeTyping);
             }
-            System.Diagnostics.Debugger.Break();
+            
             def res = 
               match (fnc.ty.FixedValue)
               {

--- a/ncc/typing/Typer.n
+++ b/ncc/typing/Typer.n
@@ -4002,30 +4002,34 @@ namespace Nemerle.Compiler
             }
             
             def res = 
-              match (fnc.ty.FixedValue)
-              {
-                // If fnc is typed to type, we need to check for @() operator.
-                | FixedType.Class(tc, args) =>
-                  def opCall = tc.LookupMember("()");
-                  match (opCall)
-                  {
-                    | [] => typeCall()
-                    | _ =>
-                      // Convert a(params) to A.@()(params)
-                      def type =
-                        PExpr.FromSystemType(
-                          Manager,
-                          tc.SystemType.FullName,
-                          args.Map(a => a.TypeInfo.ToString()));
-                      def newExpr = 
-                        PExpr.Call(
-                          PExpr.Member(type, PT.Splicable.Name(PT.Name("()"))),
-                          pfnc :: parms);
+              // Check for @() only for Fixed types
+              if (fnc.ty.IsFixed && fnc.ty.LowerBound != null)
+                match (fnc.ty.FixedValue)
+                {
+                  // If fnc is typed to type, we need to check for @() operator.
+                  | FixedType.Class(tc, args) =>
+                    def opCall = tc.LookupMember("()");
+                    match (opCall)
+                    {
+                      | [] => typeCall()
+                      | _ =>
+                        // Convert a(params) to A.@()(params)
+                        def type =
+                          PExpr.FromSystemType(
+                            Manager,
+                            tc.SystemType.FullName,
+                            args.Map(a => a.TypeInfo.ToString()));
+                        def newExpr = 
+                          PExpr.Call(
+                            PExpr.Member(type, PT.Splicable.Name(PT.Name("()"))),
+                            pfnc :: parms);
                         
-                      TypeExpr(newExpr);
-                  }
-                | _ => typeCall()
-             };
+                        TypeExpr(newExpr);
+                    }
+                  | _ => typeCall()
+                }
+              else
+                typeCall();
             res
         };
 

--- a/ncc/typing/Typer.n
+++ b/ncc/typing/Typer.n
@@ -3812,7 +3812,6 @@ namespace Nemerle.Compiler
       }
     }
 
-
     TypeCall(callExpr    : PExpr,
              pfnc        : PExpr,
              parms       : list [PExpr],
@@ -4001,46 +4000,29 @@ namespace Nemerle.Compiler
                           var_args = false,
                           final = !Manager.IsSpeculativeTyping);
             }
-                      
+            System.Diagnostics.Debugger.Break();
             def res = 
-              match (fnc.ty.FixedValue, pfnc)
+              match (fnc.ty.FixedValue)
               {
                 // If fnc is typed to type, we need to check for @() operator.
-                | (FixedType.Class(tc, args), local is PExpr.Ref) =>
+                | FixedType.Class(tc, args) =>
                   def opCall = tc.LookupMember("()");
                   match (opCall)
                   {
                     | [] => typeCall()
                     | _ =>
-                      match (args)
-                      {
-                        | [] => 
-                          // Convert a(params) to A.@()(params)
-                      
-                          // Create recursive Member(Member(Ref(Name(), Ref(Name)...)
-                          def refName(e)
-                          {
-                            PExpr.Ref(PT.Name.NameInCurrentColor(e, local.name.context))
-                          }
-                          def parseType(l)
-                          {
-                            | [hd]     => refName(hd)
-                            | hd :: tl => PExpr.Member(parseType(tl), refName(hd))
-                            | _ => Util.ice("Type is empty")
-                          }
-                      
-                          def fullName = tc.FullName;
-                          def type = parseType(fullName.Split('.').NToList().Rev());
-                      
-                          def newExpr = 
-                            PExpr.Call(
-                              PExpr.Member(type, PT.Splicable.Name(PT.Name("()"))),
-                              local :: parms);
+                      // Convert a(params) to A.@()(params)
+                      def type =
+                        PExpr.FromSystemType(
+                          Manager,
+                          tc.SystemType.ToString(),
+                          args.Map(a => a.TypeInfo.ToString()));
+                      def newExpr = 
+                        PExpr.Call(
+                          PExpr.Member(type, PT.Splicable.Name(PT.Name("()"))),
+                          pfnc :: parms);
                         
-                          TypeExpr(newExpr);
-                        | _ =>
-                          typeCall()
-                      }
+                      TypeExpr(newExpr);
                   }
                 | _ => typeCall()
              };

--- a/ncc/typing/Typer.n
+++ b/ncc/typing/Typer.n
@@ -4002,34 +4002,30 @@ namespace Nemerle.Compiler
             }
             
             def res = 
-              // Check for @() only for Fixed types
-              if (fnc.ty.IsFixed && fnc.ty.LowerBound != null)
-                match (fnc.ty.FixedValue)
-                {
+              match (fnc.ty.Hint)
+              {
+                | Some(FixedType.Class(tc, args)) =>
                   // If fnc is typed to type, we need to check for @() operator.
-                  | FixedType.Class(tc, args) =>
-                    def opCall = tc.LookupMember("()");
-                    match (opCall)
-                    {
-                      | [] => typeCall()
-                      | _ =>
-                        // Convert a(params) to A.@()(params)
-                        def type =
-                          PExpr.FromSystemType(
-                            Manager,
-                            tc.SystemType.FullName,
-                            args.Map(a => a.TypeInfo.ToString()));
-                        def newExpr = 
-                          PExpr.Call(
-                            PExpr.Member(type, PT.Splicable.Name(PT.Name("()"))),
-                            pfnc :: parms);
+                  def opCall = tc.LookupMember("()");
+                  match (opCall)
+                  {
+                    | [] => typeCall()
+                    | _ =>
+                      // Convert a(params) to A.@()(params)
+                      def type =
+                        PExpr.FromSystemType(
+                          Manager,
+                          tc.SystemType.FullName,
+                          args.Map(a => a.TypeInfo.ToString()));
+                      def newExpr = 
+                        PExpr.Call(
+                          PExpr.Member(type, PT.Splicable.Name(PT.Name("()"))),
+                          pfnc :: parms);
                         
-                        TypeExpr(newExpr);
-                    }
-                  | _ => typeCall()
-                }
-              else
-                typeCall();
+                      TypeExpr(newExpr);
+                  }
+                | _ => typeCall()
+              };
             res
         };
 

--- a/ncc/typing/Typer.n
+++ b/ncc/typing/Typer.n
@@ -4004,7 +4004,7 @@ namespace Nemerle.Compiler
             def res = 
               match (fnc.ty.Hint)
               {
-                | Some(FixedType.Class(tc, args)) =>
+                | Some(FixedType.Class(tc, _) as c) =>
                   // If fnc is typed to type, we need to check for @() operator.
                   def opCall = tc.LookupMember("()");
                   match (opCall)
@@ -4012,11 +4012,7 @@ namespace Nemerle.Compiler
                     | [] => typeCall()
                     | _ =>
                       // Convert a(params) to A.@()(params)
-                      def type =
-                        PExpr.FromSystemType(
-                          Manager,
-                          tc.SystemType.FullName,
-                          args.Map(a => a.TypeInfo.ToString()));
+                      def type = PExpr.FromTypeVar(Manager, c);
                       def newExpr = 
                         PExpr.Call(
                           PExpr.Member(type, PT.Splicable.Name(PT.Name("()"))),


### PR DESCRIPTION
Adds support for overloading '()'.
This allows to write code which looks like objects constructor while creating object types:

``` nemerle
class jQueryClass
{
  public static @()(_ : jQueryClass, s : string) : int { 1 }
  public static @()(_ : jQueryClass, s : int) : string { "#div" }
}

def jQuery = jQueryClass();

jQuery("#div") // 1
jQuery(1) // #div
```

P.S.
There is no compile time penalty, since expression in 'a()', the 'a' will be never typed as FixedType.Class in a regular code.
Only for oveloading '()' it will be typed as FixedType.Class.
