### PR TITLE
nemerle.el: Fix file header for ELPA compatibility

### DIFF
--- a/misc/nemerle.el
+++ b/misc/nemerle.el
@@ -1,4 +1,4 @@
-;;; nemerle.el -- major mode for editing nemerle programs
+;;; nemerle.el --- major mode for editing nemerle programs
 
 ;; Copyright (C) 2003-2005 The University of Wroclaw
 ;; All rights reserved.


### PR DESCRIPTION
This small fix allows `package-install-file` to install the library; without the fix, the format is considered invalid.
