### PR TITLE
Fix putting FileIOPermissionAttribute

### DIFF
--- a/ncc/generation/HierarchyEmitter.n
+++ b/ncc/generation/HierarchyEmitter.n
@@ -1026,9 +1026,6 @@ namespace Nemerle.Compiler
           $"Can't define method '$Name' (attrs: $attrs) in type '$tb'.\nError: $(e.Message)", e);
       }
 
-      Manager.AttributeCompiler.GetPermissionSets(Manager.CoreEnv, modifiers.custom_attrs)
-        .Iter((method_base :> SRE.MethodBuilder).AddDeclarativeSecurity);
-
       GetMethodInfo().SetSignature(
         fun_header.ReturnType.GetSystemType(),
         fun_header.GetRetTypeRequiredModifiers(),
@@ -1036,6 +1033,9 @@ namespace Nemerle.Compiler
         param_types(),
         fun_header.GetParamTypeRequiredModifiers(),
         fun_header.GetParamTypeOptionalModifiers());
+        
+      Manager.AttributeCompiler.GetPermissionSets(Manager.CoreEnv, modifiers.custom_attrs)
+        .Iter((method_base :> SRE.MethodBuilder).AddDeclarativeSecurity);
 
       /* add the runtime modifiers for delegate methods */
       when (DeclaringType.IsDelegate) {

--- a/ncc/testsuite/positive/Issue-git-0507.n
+++ b/ncc/testsuite/positive/Issue-git-0507.n
@@ -1,0 +1,32 @@
+using System;
+using System.Console;
+using System.Security.Permissions;
+
+namespace Testing
+{
+  public abstract class Test
+  {
+    [FileIOPermission(SecurityAction.Demand)]
+    public abstract Foo(bar : string) : void;
+  }
+  
+  public sealed class Test2 : Test
+  {
+    [FileIOPermission(SecurityAction.Demand)]
+    public override Foo(bar : string) : void { WriteLine(bar); }
+  }
+  
+  module Program
+  {
+    Main() : void
+    {
+      Test2().Foo("A");
+    }
+  }
+}
+
+/*
+BEGIN-OUTPUT
+A
+END-OUTPUT
+*/


### PR DESCRIPTION
First set signature, then add security attributes as it is done in CreateConstructorBuilder method.

Fixes #507
