### PR TITLE
Change AssemblyVersionFromSVN to use 'svn info --xml' for calculating revision number of repository. This is more portable as simple 'svn info' can be localized and use different names for 'Revision'

### DIFF
--- a/macros/Util.n
+++ b/macros/Util.n
@@ -394,35 +394,32 @@ namespace Nemerle.Utility
 
     public GetRevisionGeneric (path : string) : int
     {
-      // Execute "svn info"
+      // Execute "svn info --xml"
       def process = System.Diagnostics.Process ();
       process.StartInfo.UseShellExecute = false;
       process.StartInfo.FileName = "svn";
-      process.StartInfo.Arguments = "info";
+      process.StartInfo.Arguments = "info --xml";
       process.StartInfo.RedirectStandardOutput = true;
       process.StartInfo.WorkingDirectory = path;
 
       // Read svn output line by line until regex is matched
-      def loop(reader) : int {
-        match (reader.ReadLine ()) {
-        | null => -5
-        | line => def pattern = @"Revision:\s+(?<rev>\d+)";
-                  def regex = System.Text.RegularExpressions.Regex (pattern);
-                  def mc = regex.Match (line);
-                  mutable revision;
-
-                  if (mc.Success && int.TryParse (mc.Groups["rev"].Value, out revision))
-                    revision;
-                  else
-                    loop (reader);
-        }
+      def parse_revision(reader) : int {
+        def pattern = @"<commit\s+revision\s*=\s*""(?<rev>\d+)""";
+        def regex = System.Text.RegularExpressions.Regex (pattern);
+        def contents = reader.ReadToEnd ();        
+        def mc = regex.Match (contents);
+        mutable revision;
+        if (mc.Success && int.TryParse (mc.Groups["rev"].Value, out revision))
+          revision;
+        else
+          -5;
       }
 
       try
       {
         _ = process.Start();
 
-        def revision = loop (process.StandardOutput);
+        def revision = parse_revision (process.StandardOutput);
 
         // Wait for svn client process to terminate
         unless (process.WaitForExit (2000))


### PR DESCRIPTION
Fix for https://github.com/rsdn/nemerle/issues/506
