### PR TITLE
Fix the "xml" prefix handling (#371).

### DIFF
--- a/snippets/Nemerle.Xml/Nemerle.Xml.Macro/DefineXmlns.n
+++ b/snippets/Nemerle.Xml/Nemerle.Xml.Macro/DefineXmlns.n
@@ -26,7 +26,13 @@ namespace Nemerle.Xml
     {
       Macros.DefineCTX(typer);
       
-      if (nsVars.Contains(nsPrefix))
+      // The special prefix "xml" is handled ahead of others.
+      // The namespace is usually omitted to declare in XML documents.
+      if (nsPrefix == "xml")
+      {
+        <[ System.Xml.Linq.XNamespace.Xml.GetName($(name : string)); ]>
+      }
+      else if (nsVars.Contains(nsPrefix))
       {
         <[ $(nsPrefix : usesite).GetName($(name : string)); ]>
       }

--- a/snippets/Nemerle.Xml/Nemerle.Xml.Macro/XmlAstToXLinq.n
+++ b/snippets/Nemerle.Xml/Nemerle.Xml.Macro/XmlAstToXLinq.n
@@ -126,6 +126,14 @@ namespace Nemerle.Xml
           def (nsAttrDef, cont, xmlNsVars) = content.Fold(([], [], []), (x, (nsAttrDef, cont, nsVarsDef)) => 
             match (x)
             {
+              // The prefix "xml" is bound to "http://www.w3.org/XML/1998/namespace" by default.
+              // The value can be declared explicitly, but cannot be changed.
+              | XmlAst.Attr(Splicable.PrefiedName("xmlns", "xml"), Splicable.Value("http://www.w3.org/XML/1998/namespace")) =>
+                def xmlNs = <[ L.XAttribute(L.XNamespace.Xmlns.GetName("xml"), "http://www.w3.org/XML/1998/namespace") ]>;
+                (xmlNs :: nsAttrDef, cont, nsVarsDef)
+              | XmlAst.Attr(Splicable.PrefiedName("xmlns", "xml"), _) =>
+                Message.Error(<#The prefix "xml" is reserved.#>);
+                (nsAttrDef, cont, nsVarsDef)
               | XmlAst.Attr(Splicable.PrefiedName("xmlns", name) as attr, Splicable.Value(val)) => 
                 nsVars2 = nsVars2.Add(name);
                 Util.locate(ToLocation(attr), 


### PR DESCRIPTION
This patch fixes the problem when the "xml" prefix is contained in XML literals.
