### PR TITLE
INotifyPropertyChanged autoimplementation macro set

### DIFF
--- a/NemerleAll.nproj
+++ b/NemerleAll.nproj
@@ -308,7 +308,7 @@
     </CreateItem>
     <!--Delete Files="@(CompilerTestsFiles)" /  DONT WORK WITH READONLY FILES!-->
     <Exec Command="IF EXIST $(NBin)\Tests\ DEL $(NBin)\Tests\ /F /S /Q" WorkingDirectory="$(NBin)\" />
-    <Copy SourceFiles="$(NBin)\Linq\Nemerle.Linq.dll;$(NBin)\Unsafe\Nemerle.Unsafe.dll;@(CSharpCompilerFiles)" DestinationFolder="$(NBin)\Tests\positive" />
+    <Copy SourceFiles="$(NBin)\Linq\Nemerle.Linq.dll;$(NBin)\Unsafe\Nemerle.Unsafe.dll;$(NBin)\PowerPack\Nemerle.WPF.dll;@(CSharpCompilerFiles)" DestinationFolder="$(NBin)\Tests\positive" />
     <Copy SourceFiles="$(NBin)\Linq\Nemerle.Linq.dll;$(NBin)\Unsafe\Nemerle.Unsafe.dll;$(NBin)\PowerPack\Nemerle.WPF.dll;@(CSharpCompilerFiles)" DestinationFolder="$(NBin)\Tests\negative" />
     <!--Delete all temporary files in old testing directory-->
     <CreateItem Include="$(NRoot)\ncc\testsuite\*.exe;$(NRoot)\ncc\testsuite\*.dll;$(NRoot)\ncc\testsuite\*.pdb">
@@ -421,7 +421,7 @@
   </Target>
 
   <!--Helper target to build Nemerle.WPF -->
-  <Target Name="_Wpf" Condition="'$(TargetFrameworkVersion)' == 'v4.0' Or '$(TargetFrameworkVersion)' == 'v4.5' Or '$(TargetFrameworkVersion)' == 'v4.5.1'">
+  <Target Name="_Wpf" Condition="'$(TargetFrameworkVersion)' == 'v3.0' Or '$(TargetFrameworkVersion)' == 'v3.5' Or '$(TargetFrameworkVersion)' == 'v4.0' Or '$(TargetFrameworkVersion)' == 'v4.5' Or '$(TargetFrameworkVersion)' == 'v4.5.1'">
     <MSBuild Projects="@(NWpf)" Properties="OutputPath=$(NBin)\PowerPack\; IntermediateOutputPath=$(NObj)\PowerPack\; Nemerle=$(NCurBin); NemerlePowerPack=$(NBin)\PowerPack; Configuration=$(Configuration); NKeysDir=$(NBin)\keys" Targets="$(NTargetName)" />    
   </Target>
 

--- a/NemerleAll.nproj
+++ b/NemerleAll.nproj
@@ -96,7 +96,6 @@
   <!--Projects related to PowerPack-->
   <ItemGroup>
     <NPowerPack Include="$(NRoot)\snippets\Nemerle.Xml\Nemerle.Xml.Macro\Nemerle.Xml.Macro.nproj" />
-    <NPowerPack Include="$(NRoot)\snippets\Nemerle.WPF\Nemerle.WPF\Nemerle.WPF.nproj" />
     <NPowerPack Include="$(NRoot)\snippets\ObjectExpressions\NewObjectMacro\NewObjectMacro.nproj" />
     <NPowerPack Include="$(NRoot)\snippets\Nemerle.Diff\Nemerle.Diff\Nemerle.Diff.nproj" />
     <NPowerPack Include="$(NRoot)\snippets\aop\DevMacros.nproj" />
@@ -111,6 +110,10 @@
 
   <ItemGroup>
     <NUnsafe Include="$(NRoot)\snippets\Nemerle.Unsafe\Nemerle.Unsafe\Nemerle.Unsafe.nproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <NWpf Include="$(NRoot)\snippets\Nemerle.WPF\Nemerle.WPF\Nemerle.WPF.nproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -295,7 +298,7 @@
   </Target>
 
   <!--Runs compiler tests.-->
-  <Target Name="CompilerTests" DependsOnTargets="Linq;Unsafe;_PegAndCSharp;TestFramework">
+  <Target Name="CompilerTests" DependsOnTargets="Linq;Unsafe;_PegAndCSharp;TestFramework;_Wpf">
     <PropertyGroup>
       <NTeamCityPositiveTestArguments Condition=" '$(TEAMCITY_VERSION)' != '' ">"-team-city-test-suite:Ncc-Positive-$(NVer)"</NTeamCityPositiveTestArguments>
       <NTeamCityNegativeTestArguments Condition=" '$(TEAMCITY_VERSION)' != '' ">"-team-city-test-suite:Ncc-Negative-$(NVer)"</NTeamCityNegativeTestArguments>
@@ -306,7 +309,7 @@
     <!--Delete Files="@(CompilerTestsFiles)" /  DONT WORK WITH READONLY FILES!-->
     <Exec Command="IF EXIST $(NBin)\Tests\ DEL $(NBin)\Tests\ /F /S /Q" WorkingDirectory="$(NBin)\" />
     <Copy SourceFiles="$(NBin)\Linq\Nemerle.Linq.dll;$(NBin)\Unsafe\Nemerle.Unsafe.dll;@(CSharpCompilerFiles)" DestinationFolder="$(NBin)\Tests\positive" />
-    <Copy SourceFiles="$(NBin)\Linq\Nemerle.Linq.dll;$(NBin)\Unsafe\Nemerle.Unsafe.dll;@(CSharpCompilerFiles)" DestinationFolder="$(NBin)\Tests\negative" />
+    <Copy SourceFiles="$(NBin)\Linq\Nemerle.Linq.dll;$(NBin)\Unsafe\Nemerle.Unsafe.dll;$(NBin)\PowerPack\Nemerle.WPF.dll;@(CSharpCompilerFiles)" DestinationFolder="$(NBin)\Tests\negative" />
     <!--Delete all temporary files in old testing directory-->
     <CreateItem Include="$(NRoot)\ncc\testsuite\*.exe;$(NRoot)\ncc\testsuite\*.dll;$(NRoot)\ncc\testsuite\*.pdb">
       <Output ItemName="NTestSuiteTempFiles" TaskParameter="Include"/>
@@ -417,8 +420,13 @@
     <!--<Exec Command="&quot;$(NBin)\PowerPack\fsmtest.exe&quot;" />-->
   </Target>
 
+  <!--Helper target to build Nemerle.WPF -->
+  <Target Name="_Wpf" Condition="'$(TargetFrameworkVersion)' == 'v4.0' Or '$(TargetFrameworkVersion)' == 'v4.5' Or '$(TargetFrameworkVersion)' == 'v4.5.1'">
+    <MSBuild Projects="@(NWpf)" Properties="OutputPath=$(NBin)\PowerPack\; IntermediateOutputPath=$(NObj)\PowerPack\; Nemerle=$(NCurBin); NemerlePowerPack=$(NBin)\PowerPack; Configuration=$(Configuration); NKeysDir=$(NBin)\keys" Targets="$(NTargetName)" />    
+  </Target>
+
   <!--Helper target to build power pack-->
-  <Target Name="_PowerPack" DependsOnTargets="_PegAndCSharp; Unsafe; TestFramework; _ComputationExpressions; _Async; _Statechart">
+  <Target Name="_PowerPack" DependsOnTargets="_PegAndCSharp; Unsafe; TestFramework; _ComputationExpressions; _Async; _Statechart; _Wpf">
     <MSBuild Projects="@(NPowerPack)" Properties="OutputPath=$(NBin)\PowerPack\; IntermediateOutputPath=$(NObj)\PowerPack\; Nemerle=$(NCurBin); Configuration=$(Configuration); NKeysDir=$(NBin)\keys" Targets="$(NTargetName)" />
   </Target>
 

--- a/ncc/testsuite/negative/notifypropertychanged.n
+++ b/ncc/testsuite/negative/notifypropertychanged.n
@@ -1,0 +1,29 @@
+﻿// REFERENCE: Nemerle.WPF.dll
+using Nemerle.WPF;
+
+[NotifyPropertyChanged] // E: Duplicates of 'NotifyPropertyChanged' macroattribute are not allowed.
+[NotifyPropertyChanged]
+class A {}
+
+[NotifyPropertyChanged("Method")] // E: Specify a valid method for property changed event raising
+class A1 {}
+
+[NotifyPropertyChanged]
+public class A2
+{
+    [NotifyChangedOptions(HideSelfChanges)] // W: NotifyChangedOptions macro ignored on property without a setter.
+    public Prop       : int { get; }
+
+    [NotifyChangedOptions(Dependent = [Prop3, Prop], HideSelfChanges)] // E: Class 'A2' does not contain a property with the name 'Prop3'.
+    public Prop2 : string { get; set; }
+    
+    [NotifyChangedOptions(Dependent = ["Prop3 + 7"], HideSelfChanges)] // E: Expected simple name
+    public Prop4 : string { get; set; }
+    
+    public CustomNotify() : void
+    {
+        RaisePropertyChanged("test"+7);    // E: Specify a property for changed event raising
+        RaisePropertyChanged(Prop5);       // E: Class 'A2' does not contain a property with the name 'Prop5'.
+        RaisePropertyChanged(Prop, Raise); // E: Specify a valid method for property changed event raising
+    }
+}

--- a/ncc/testsuite/negative/notifypropertychanged.n
+++ b/ncc/testsuite/negative/notifypropertychanged.n
@@ -1,0 +1,32 @@
+﻿// REFERENCE: Nemerle.WPF.dll
+using Nemerle.WPF;
+
+[NotifyPropertyChanged]
+public delegate Foo() : void; // E: Macro NotifyPropertyChanged is not valid on this declaration type. It is only valid on 'class' declarations.
+
+[NotifyPropertyChanged] // E: Duplicates of 'NotifyPropertyChanged' macroattribute are not allowed.
+[NotifyPropertyChanged]
+class A {}
+
+[NotifyPropertyChanged("Method")] // E: Specify a valid method for property changed event raising (e.g. \[NotifyPropertyChanged(OnPropertyChanged)\])
+class A1 {}
+
+[NotifyPropertyChanged]
+public class A2
+{
+    [NotifyChangedOptions(HideSelfChanges)] // W: NotifyChangedOptions macro ignored on property without a setter.
+    public Prop       : int { get; }
+
+    [NotifyChangedOptions(Dependent = [Prop3, Prop], HideSelfChanges)] // E: Class 'A2' does not contain a property with the name 'Prop3'.
+    public Prop2 : string { get; set; }
+    
+    [NotifyChangedOptions(Dependent = ["Prop3 + 7"], HideSelfChanges)] 
+    public Prop4 : string { get; set; }
+    
+    public CustomNotify() : void
+    {
+        RaisePropertyChanged("test"+7);    // E: Specify a property for changed event raising (e.g. RaisePropertyChanged(PropName)).
+        RaisePropertyChanged(Prop5);       // E: Class 'A2' does not contain a property with the name 'Prop5'.
+        RaisePropertyChanged(Prop, Raise); // E: Specify a valid method for property changed event raising (e.g. RaisePropertyChanged(PropName, OnPropertyChanged)).
+    }
+}

--- a/ncc/testsuite/positive/notifypropertychanged.n
+++ b/ncc/testsuite/positive/notifypropertychanged.n
@@ -1,19 +1,10 @@
-﻿using Nemerle.Assertions;
-using Nemerle.Collections;
-using Nemerle.Extensions;
-using Nemerle.Utility;
+// REFERENCE: Nemerle.WPF.dll
+using Nemerle.Assertions;
 using Nemerle.WPF;
 
 using System;
-using System.ComponentModel;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Media;
-
-using System.Console;
 
 [NotifyPropertyChanged]
 public class Person
@@ -22,23 +13,23 @@ public class Person
 
     [NotifyChangedOptions(Dependent = [Age, FullNameAndAge], HideSelfChanges)]
     public BirthDate : DateTime { get; set; }
-    
+
     [NotifyChangedOptions(Dependent = FullNameAndAge)]
     public FirstName : string { get; set; }
-    
+
     [NotifyChangedOptions(Dependent = FullNameAndAge)]
     public LastName  : string { get; set; }
-    
+
     public FullNameAndAge  : string { get { $"$FirstName $LastName $Age"} }
-    
+
     [NotifyChangedOptions(HideSelfChanges)]
     public IgnoredProperty : string { get; set; }
-    
+
     public RaiseIgnoredPropertyChanged() : void
     {
         RaisePropertyChanged(IgnoredProperty);
     }
-    
+
     public RaiseAllPropertiesChanged() : void
     {
         RaisePropertyChanged(null); //"null for the propertyName parameter indicates that all of the properties have changed" (http://msdn.microsoft.com/en-us/library/system.componentmodel.propertychangedeventargs.propertyname.aspx)
@@ -49,39 +40,60 @@ public class Person
 public class Student : Person
 {
     public Id : uint { get; set; }
-}
+} 
 
-public module PersonTests
+public module Tests
 {
-    public Run() : void
+    public static Main() : void
     {
+        def PrintEventData(eventData)
+        {
+            foreach(keyValue in eventData)
+                Console.WriteLine($"$(keyValue.Key), $(keyValue.Value)");
+        }
+        
         def person = Person();
         def eventData = Dictionary();
         person.PropertyChanged += (_, e) => { if (eventData.ContainsKey(e.PropertyName)) eventData[e.PropertyName] += 1 else eventData[e.PropertyName] = 1 }
-        
+
         person.BirthDate = DateTime.Now;
         assert(eventData["Age"] == 1);
         assert(eventData["FullNameAndAge"] == 1);
-        assert(!eventData.ContainsKey("BirthDate")); //BirthDate marked with HideSelfChanges option 
-        
+        assert(!eventData.ContainsKey("BirthDate")); //BirthDate marked with HideSelfChanges option
+        PrintEventData(eventData);
+
         eventData.Clear();
         person.IgnoredProperty = "value";
         assert(!eventData.Any());
-        
+        PrintEventData(eventData);
+
         eventData.Clear();
         person.RaiseIgnoredPropertyChanged();
         assert(eventData["IgnoredProperty"] == 1);
-        
+        PrintEventData(eventData);
+
         mutable allPropsChanged;
         def person1 = Person();
         person1.PropertyChanged += (_, e) => { allPropsChanged = (e.PropertyName == null) }
         person1.RaiseAllPropertiesChanged();
         assert(allPropsChanged);
-        
+        Console.WriteLine(allPropsChanged);
+
         eventData.Clear();
         def student = Student();
         student.PropertyChanged += (_, e) => { if (eventData.ContainsKey(e.PropertyName)) eventData[e.PropertyName] += 1 else eventData[e.PropertyName] = 1 };
         student.Id = 123;
         assert(eventData["Id"] == 1);
+        PrintEventData(eventData);
     }
 }
+
+/*
+BEGIN-OUTPUT
+Age, 1
+FullNameAndAge, 1
+IgnoredProperty, 1
+True
+Id, 1
+END-OUTPUT
+*/

--- a/snippets/Nemerle.WPF/Nemerle.WPF/Nemerle.WPF.nproj
+++ b/snippets/Nemerle.WPF/Nemerle.WPF/Nemerle.WPF.nproj
@@ -62,6 +62,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DependencyProperty.n" />
+    <Compile Include="NotifyPropertyChanged.n" />
     <Compile Include="Properties\AssemblyInfo.n" />
   </ItemGroup>
   <ItemGroup>

--- a/snippets/Nemerle.WPF/Nemerle.WPF/NotifyPropertyChanged.n
+++ b/snippets/Nemerle.WPF/Nemerle.WPF/NotifyPropertyChanged.n
@@ -1,0 +1,288 @@
+﻿using Nemerle;
+using Nemerle.Compiler;
+using Nemerle.Compiler.Parsetree;
+
+using System;
+using SCG = System.Collections.Generic;
+using System.Linq;
+
+namespace Nemerle.WPF
+{
+    using NotifyPropertyChangedHelper;
+
+    [MacroUsage(MacroPhase.BeforeInheritance, MacroTargets.Class, Inherited = false, AllowMultiple = false)]  
+    public macro NotifyPropertyChanged(tb : TypeBuilder, raiseChangedMethod = null)
+    {
+        ignore(raiseChangedMethod);
+
+        if(tb.TrySetMacroAttributeSpecified(this))
+        {
+            AddInterface(tb);
+        }
+        else
+        {
+            Message.Error(tb.Location, 
+                          $"Duplicates of '$(GetMacroName())' macroattribute are not allowed.");    
+        }
+    }
+
+    [MacroUsage(MacroPhase.BeforeTypedMembers, MacroTargets.Class, Inherited = false, AllowMultiple = false)]  
+    public macro NotifyPropertyChanged(tb : TypeBuilder, raiseChangedMethod = <[ () ]>)
+    {
+        when(tb.TrySetMacroAttributeSpecified(this))
+            ImplementInterface(Macros.ImplicitCTX(), tb, raiseChangedMethod, GetMacroName());
+    }
+
+    [MacroUsage(MacroPhase.WithTypedMembers, MacroTargets.Class, Inherited = false, AllowMultiple = false)]  
+    public macro NotifyPropertyChanged(tb : TypeBuilder, raiseChangedMethod =  null)
+    {
+        ignore(raiseChangedMethod);
+
+        when(tb.TrySetMacroAttributeSpecified(this))
+            RewriteSetters(tb, GetMacroName());
+    }
+
+    public macro RaisePropertyChanged(property : PExpr, raiseChangedMethod = <[ () ]>)
+    {
+        CreateRaiseChangedMethodCall(Macros.ImplicitCTX().CurrentTypeBuilder,
+                                     property,
+                                     raiseChangedMethod,
+                                     GetMacroName());
+    }
+
+    [MacroUsage(MacroPhase.BeforeInheritance, MacroTargets.Property, Inherited = false, AllowMultiple = false)]  
+    public macro NotifyChangedOptions(tb : TypeBuilder, property : ParsedProperty, params options : list[PExpr])
+    {
+        if(tb.TrySetMacroAttributeSpecified(this, property.Name))
+        {
+            SetOptions(tb, property, GetMacroName(), options);
+        }
+        else
+        {
+            Message.Error(property.Location, 
+                          $"Duplicates of '$(GetMacroName())' macroattribute are not allowed."); 
+        }
+    }
+
+    module NotifyPropertyChangedHelper
+    {       
+        public AddInterface(tb : TypeBuilder) : void
+        {
+            tb.AddImplementedInterface(<[ System.ComponentModel.INotifyPropertyChanged ]>);
+        }
+
+        public ImplementInterface(typer              : Typer, 
+                                  tb                 : TypeBuilder, 
+                                  raiseChangedMethod : PExpr, 
+                                  macroName          : string) : void
+        {
+            def ImplementInterface()
+            {
+                Macros.DefineCTX(typer);
+
+                def interfaceAlreadyImplemented = tb.BaseClass.TryRequire(<[ ttype: System.ComponentModel.INotifyPropertyChanged ]>);
+
+                def raiseChangedMethodName = match(raiseChangedMethod)
+                                                {
+                                                    | <[ $(methodName : name) ]> => methodName
+                                                    | <[()]> => _defaultRaiseChangedMethodName
+                                                    | e => Message.Error(e.Location, 
+                                                                    $"Specify a valid method for property changed event raising (e.g. $macroName(OnPropertyChanged)).");
+                                                        _defaultRaiseChangedMethodName
+                                                };
+
+                unless (interfaceAlreadyImplemented)
+                {
+                    tb.Define(<[ decl: public event PropertyChanged : System.ComponentModel.PropertyChangedEventHandler; ]>);
+
+                    def raiseChangedMethodDecl = <[ decl:
+                                                    protected virtual $(raiseChangedMethodName : name)(propertyName: string) : void
+                                                    {
+                                                        def handler = PropertyChanged;
+                                                        when (handler != null)
+                                                            handler(this, System.ComponentModel.PropertyChangedEventArgs(propertyName));
+                                                    }]>;
+
+                    tb.Define(raiseChangedMethodDecl);
+                }
+
+                SetRaiseChangedMethodName(tb, raiseChangedMethodName);
+            }
+
+            if (tb.IsDelegate  || 
+                tb.IsEnum      || 
+                tb.IsInterface || 
+                tb.IsModule)
+                Message.Error(tb.Location, $"Macro $macroName is not valid on this declaration type. It is only valid on 'class' declarations.");
+            else
+                ImplementInterface()
+        }
+
+        public CreateRaiseChangedMethodCall(tb : TypeBuilder, property : PExpr, raiseChangedMethod : PExpr, macroName : string) : PExpr
+        {
+            def OnError(loc, message)
+            {
+                Message.Error(loc, message);
+                <[]>
+            }
+
+            def OnRaiseChangedMethodNotFound()
+            {
+                OnError(raiseChangedMethod.Location, $"Specify a valid method for property changed event raising (e.g. $macroName(PropName, OnPropertyChanged)).")
+            }
+
+            def GetRaiseChangedMethodCall(propExpr, raiseChangedMethodName : option[Name])
+            {
+                def propName = propExpr.name.Id;
+                match(tb.GetProperties().Filter(prop => prop.Name == propName))
+                {
+                   | [_] => raiseChangedMethodName.Map(methodName => <[ $(methodName : name)($(propName : string)); ]>) ?? 
+                            OnRaiseChangedMethodNotFound()
+                   | []  => OnError(propExpr.Location, $"Class '$(tb.FullName)' does not contain a property with the name '$propName'.")
+                   | _::_ => assert(false, $"Two or more properties with the same name found ($propName).")
+                }
+            }
+
+            def raiseChangedMethodName = 
+                             match(raiseChangedMethod)
+                             {
+                                 | <[ $(methodName : name) ]> 
+                                 | <[()]> when tb.UserData.Contains(_raiseChangedMethodKey) 
+                                          with methodName = GetRaiseChangedMethodName(tb)
+                                 | <[()]> with methodName = _defaultRaiseChangedMethodName
+                                      => if (tb.MethodExists(methodName)) Some(methodName) else None()
+                                 | _  => None()
+                             };
+
+            match(property)
+            {
+                | propExpr is PExpr.Ref => GetRaiseChangedMethodCall(propExpr, raiseChangedMethodName)
+                | <[ null ]> => raiseChangedMethodName.Map(methodName => <[ $(methodName : name)(null); ]>) ?? 
+                                OnRaiseChangedMethodNotFound()
+                | e => OnError(e.Location, $"Specify a property for changed event raising (e.g. $macroName(PropName)).")
+            }
+        }
+
+        public RewriteSetters(tb : TypeBuilder, macroName : string) : void
+        {
+            def GetDependentProps(tb, propertyName)
+            {
+                if(!tb.UserData.Contains((_dependentPropsKey, propertyName)))
+                    []
+                else
+                    tb.UserData[(_dependentPropsKey, propertyName)] :> list[PExpr]
+            }
+
+            def ValidateDependentProps(dependentProps)
+            {
+                foreach(dependentProp in dependentProps)
+                {
+                    | dependentProp is PExpr.Ref 
+                        when !tb.GetProperties().Exists(prop => prop.Name == dependentProp.name.Id) =>
+                        Message.Error(dependentProp.Location, $"Class '$(tb.FullName)' does not contain a property with the name '$dependentProp'.")
+                    | _ is PExpr.Ref => ()
+                    | _ => Message.Error(dependentProp.Location, "Expected simple name.")
+                }
+            }
+
+            def GetRaiseChangedMethodCalls(methodName, propertyName)
+            {
+                def dependentProps = GetDependentProps(tb, propertyName);
+
+                ValidateDependentProps(dependentProps);
+
+                def selfSetterRaising = 
+                    if(_ignoredProperties.Contains(tb, propertyName))
+                        <[]>
+                    else 
+                        <[ $(methodName : name)($(propertyName : string)); ]>;
+
+                selfSetterRaising::dependentProps.
+                                   OfType.[PExpr.Ref]().
+                                   Map(prop => <[ $(methodName : name)($(prop.name.Id : string)) ]>)
+            }
+
+            def raiseChangedMethodName = GetRaiseChangedMethodName(tb);
+
+            if(!tb.MethodExists(raiseChangedMethodName))
+            {
+                Message.Error(tb.Location, 
+                              $"Specify a valid method for property changed event raising (e.g. [$macroName(OnPropertyChanged)]).");
+            }
+            else
+            {
+                def properties = tb.GetProperties(BindingFlags.DeclaredOnly | 
+                                                  BindingFlags.Instance     | 
+                                                  BindingFlags.Public       | 
+                                                  BindingFlags.NonPublic);
+
+                foreach(propertyBuilder is PropertyBuilder in properties)
+                {
+                    match(propertyBuilder.Setter)
+                    {
+                        | setter is MethodBuilder => 
+                            setter.Body = <[ $(setter.Body);
+                                            ..$(GetRaiseChangedMethodCalls(raiseChangedMethodName, propertyBuilder.Name)); ]>;
+                        | _ => ()
+                    }
+                }
+            }
+        }
+
+        public SetOptions(tb : TypeBuilder, property : ClassMember.Property, macroName : string, options : list[PExpr]) : void
+        {
+            def SetDependentProps(tb, propName, dependentProps)
+            {
+                tb.UserData[(_dependentPropsKey, propName)] = dependentProps
+            }
+
+            unless(property.setter.HasValue)
+                Message.Warning($"$macroName macro ignored on property without a setter.");
+
+            foreach(option in options) 
+            {
+                | <[ HideSelfChanges ]>           => _ = _ignoredProperties.Add(tb, property.Name);
+                | <[ Dependent = $prop ]> when options is [_] 
+                                          with props = [prop]
+                | <[ Dependent = [..$props] ]>    => SetDependentProps(tb, property.Name, props)
+                | e => Message.Error(e.Location, 
+                                     $"Invalid options syntax in $macroName macro, valid options are: 'Dependent = [Prop1, Prop2]' and 'HideSelfChanges'.")
+            }
+        }
+
+        public GetMacroName(this macroInstance : IMacro) : string
+        {
+            macroInstance.GetName().Split(':').First()
+        }
+
+        public TrySetMacroAttributeSpecified(this tb : TypeBuilder, macroInstance : IMacro, data : object = null) : bool
+        {
+            def key = (macroInstance.GetType().GUID, data);
+            tb.UserData[key] = !tb.UserData.Contains(key);
+            tb.UserData[key] :> bool
+        }
+
+        private MethodExists(this tb : TypeBuilder, methodName : Name) : bool
+        {
+            tb.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).
+               Exists(method => method.Name == methodName.Id)
+        }
+
+        private GetRaiseChangedMethodName(tb : TypeBuilder) : Name
+        {
+            assert(tb.UserData.Contains(_raiseChangedMethodKey));
+
+            tb.UserData[_raiseChangedMethodKey] :> Name
+        }
+
+        private SetRaiseChangedMethodName(tb : TypeBuilder, raiseChangedMethodName : Name) : void
+        {
+            tb.UserData[_raiseChangedMethodKey] = raiseChangedMethodName
+        }
+
+        private _ignoredProperties     = SCG.HashSet.[TypeBuilder * string]();
+        private _dependentPropsKey     = Guid.NewGuid();
+        private _raiseChangedMethodKey = Guid.NewGuid();
+        private _defaultRaiseChangedMethodName = Name("OnPropertyChanged");
+    }
+}

--- a/snippets/Nemerle.WPF/Nemerle.WPF/NotifyPropertyChanged.n
+++ b/snippets/Nemerle.WPF/Nemerle.WPF/NotifyPropertyChanged.n
@@ -1,0 +1,288 @@
+﻿using Nemerle;
+using Nemerle.Compiler;
+using Nemerle.Compiler.Parsetree;
+
+using System;
+using SCG = System.Collections.Generic;
+using System.Linq;
+
+namespace Nemerle.WPF
+{
+    using NotifyPropertyChangedHelper;
+
+    [MacroUsage(MacroPhase.BeforeInheritance, MacroTargets.Class, Inherited = false, AllowMultiple = false)]  
+    public macro NotifyPropertyChanged(tb : TypeBuilder, raiseChangedMethod = null)
+    {
+        ignore(raiseChangedMethod);
+
+        if(tb.TrySetMacroAttributeSpecified(this))
+        {
+            AddInterface(tb);
+        }
+        else
+        {
+            Message.Error(tb.Location, 
+                          $"Duplicates of '$(GetMacroName())' macroattribute are not allowed.");    
+        }
+    }
+
+    [MacroUsage(MacroPhase.BeforeTypedMembers, MacroTargets.Class, Inherited = false, AllowMultiple = false)]  
+    public macro NotifyPropertyChanged(tb : TypeBuilder, raiseChangedMethod = <[ () ]>)
+    {
+        when(tb.TrySetMacroAttributeSpecified(this))
+            ImplementInterface(Macros.ImplicitCTX(), tb, raiseChangedMethod, GetMacroName());
+    }
+
+    [MacroUsage(MacroPhase.WithTypedMembers, MacroTargets.Class, Inherited = false, AllowMultiple = false)]  
+    public macro NotifyPropertyChanged(tb : TypeBuilder, raiseChangedMethod =  null)
+    {
+        ignore(raiseChangedMethod);
+
+        when(tb.TrySetMacroAttributeSpecified(this))
+            RewriteSetters(tb, GetMacroName());
+    }
+
+    public macro RaisePropertyChanged(property : PExpr, raiseChangedMethod = <[ () ]>)
+    {
+        CreateRaiseChangedMethodCall(Macros.ImplicitCTX().CurrentTypeBuilder,
+                                     property,
+                                     raiseChangedMethod,
+                                     GetMacroName());
+    }
+
+    [MacroUsage(MacroPhase.BeforeInheritance, MacroTargets.Property, Inherited = false, AllowMultiple = false)]  
+    public macro NotifyChangedOptions(tb : TypeBuilder, property : ParsedProperty, params options : list[PExpr])
+    {
+        if(tb.TrySetMacroAttributeSpecified(this, property.Name))
+        {
+            SetOptions(tb, property, GetMacroName(), options);
+        }
+        else
+        {
+            Message.Error(property.Location, 
+                          $"Duplicates of '$(GetMacroName())' macroattribute are not allowed."); 
+        }
+    }
+
+    module NotifyPropertyChangedHelper
+    {       
+        public AddInterface(tb : TypeBuilder) : void
+        {
+            tb.AddImplementedInterface(<[ System.ComponentModel.INotifyPropertyChanged ]>);
+        }
+
+        public ImplementInterface(typer              : Typer, 
+                                  tb                 : TypeBuilder, 
+                                  raiseChangedMethod : PExpr, 
+                                  macroName          : string) : void
+        {
+            def ImplementInterface()
+            {
+                Macros.DefineCTX(typer);
+
+                def interfaceAlreadyImplemented = tb.BaseClass.TryRequire(<[ ttype: System.ComponentModel.INotifyPropertyChanged ]>);
+
+                def raiseChangedMethodName = match(raiseChangedMethod)
+                                                {
+                                                    | <[ $(methodName : name) ]> => methodName
+                                                    | <[()]> => _defaultRaiseChangedMethodName
+                                                    | e => Message.Error(e.Location, 
+                                                                    $"Specify a valid method for property changed event raising (e.g. [$macroName(OnPropertyChanged)]).");
+                                                        _defaultRaiseChangedMethodName
+                                                };
+
+                unless (interfaceAlreadyImplemented)
+                {
+                    tb.Define(<[ decl: public event PropertyChanged : System.ComponentModel.PropertyChangedEventHandler; ]>);
+
+                    def raiseChangedMethodDecl = <[ decl:
+                                                    protected virtual $(raiseChangedMethodName : name)(propertyName: string) : void
+                                                    {
+                                                        def handler = PropertyChanged;
+                                                        when (handler != null)
+                                                            handler(this, System.ComponentModel.PropertyChangedEventArgs(propertyName));
+                                                    }]>;
+
+                    tb.Define(raiseChangedMethodDecl);
+                }
+
+                SetRaiseChangedMethodName(tb, raiseChangedMethodName);
+            }
+
+            if (tb.IsDelegate  || 
+                tb.IsEnum      || 
+                tb.IsInterface || 
+                tb.IsModule)
+                Message.Error(tb.Location, $"Macro $macroName is not valid on this declaration type. It is only valid on 'class' declarations.");
+            else
+                ImplementInterface()
+        }
+
+        public CreateRaiseChangedMethodCall(tb : TypeBuilder, property : PExpr, raiseChangedMethod : PExpr, macroName : string) : PExpr
+        {
+            def OnError(loc, message)
+            {
+                Message.Error(loc, message);
+                <[]>
+            }
+
+            def OnRaiseChangedMethodNotFound()
+            {
+                OnError(raiseChangedMethod.Location, $"Specify a valid method for property changed event raising (e.g. $macroName(PropName, OnPropertyChanged)).")
+            }
+
+            def GetRaiseChangedMethodCall(propExpr, raiseChangedMethodName : option[Name])
+            {
+                def propName = propExpr.name.Id;
+                match(tb.GetProperties().Filter(prop => prop.Name == propName))
+                {
+                   | [_] => raiseChangedMethodName.Map(methodName => <[ $(methodName : name)($(propName : string)); ]>) ?? 
+                            OnRaiseChangedMethodNotFound()
+                   | []  => OnError(propExpr.Location, $"Class '$(tb.FullName)' does not contain a property with the name '$propName'.")
+                   | _::_ => assert(false, $"Two or more properties with the same name found ($propName).")
+                }
+            }
+
+            def raiseChangedMethodName = 
+                             match(raiseChangedMethod)
+                             {
+                                 | <[ $(methodName : name) ]> 
+                                 | <[()]> when tb.UserData.Contains(_raiseChangedMethodKey) 
+                                          with methodName = GetRaiseChangedMethodName(tb)
+                                 | <[()]> with methodName = _defaultRaiseChangedMethodName
+                                      => if (tb.MethodExists(methodName)) Some(methodName) else None()
+                                 | _  => None()
+                             };
+
+            match(property)
+            {
+                | propExpr is PExpr.Ref => GetRaiseChangedMethodCall(propExpr, raiseChangedMethodName)
+                | <[ null ]> => raiseChangedMethodName.Map(methodName => <[ $(methodName : name)(null); ]>) ?? 
+                                OnRaiseChangedMethodNotFound()
+                | e => OnError(e.Location, $"Specify a property for changed event raising (e.g. $macroName(PropName)).")
+            }
+        }
+
+        public RewriteSetters(tb : TypeBuilder, macroName : string) : void
+        {
+            def GetDependentProps(tb, propertyName)
+            {
+                if(!tb.UserData.Contains((_dependentPropsKey, propertyName)))
+                    []
+                else
+                    tb.UserData[(_dependentPropsKey, propertyName)] :> list[PExpr]
+            }
+
+            def ValidateDependentProps(dependentProps)
+            {
+                foreach(dependentProp in dependentProps)
+                {
+                    | dependentProp is PExpr.Ref 
+                        when !tb.GetProperties().Exists(prop => prop.Name == dependentProp.name.Id) =>
+                        Message.Error(dependentProp.Location, $"Class '$(tb.FullName)' does not contain a property with the name '$dependentProp'.")
+                    | _ is PExpr.Ref => ()
+                    | _ => Message.Error(dependentProp.Location, "Expected simple name.")
+                }
+            }
+
+            def GetRaiseChangedMethodCalls(methodName, propertyName)
+            {
+                def dependentProps = GetDependentProps(tb, propertyName);
+
+                ValidateDependentProps(dependentProps);
+
+                def selfSetterRaising = 
+                    if(_ignoredProperties.Contains(tb, propertyName))
+                        <[]>
+                    else 
+                        <[ $(methodName : name)($(propertyName : string)); ]>;
+
+                selfSetterRaising::dependentProps.
+                                   OfType.[PExpr.Ref]().
+                                   Map(prop => <[ $(methodName : name)($(prop.name.Id : string)) ]>)
+            }
+
+            def raiseChangedMethodName = GetRaiseChangedMethodName(tb);
+
+            if(!tb.MethodExists(raiseChangedMethodName))
+            {
+                Message.Error(tb.Location, 
+                              $"Specify a valid method for property changed event raising (e.g. [$macroName(OnPropertyChanged)]).");
+            }
+            else
+            {
+                def properties = tb.GetProperties(BindingFlags.DeclaredOnly | 
+                                                  BindingFlags.Instance     | 
+                                                  BindingFlags.Public       | 
+                                                  BindingFlags.NonPublic);
+
+                foreach(propertyBuilder is PropertyBuilder in properties)
+                {
+                    match(propertyBuilder.Setter)
+                    {
+                        | setter is MethodBuilder => 
+                            setter.Body = <[ $(setter.Body);
+                                            ..$(GetRaiseChangedMethodCalls(raiseChangedMethodName, propertyBuilder.Name)); ]>;
+                        | _ => ()
+                    }
+                }
+            }
+        }
+
+        public SetOptions(tb : TypeBuilder, property : ClassMember.Property, macroName : string, options : list[PExpr]) : void
+        {
+            def SetDependentProps(tb, propName, dependentProps)
+            {
+                tb.UserData[(_dependentPropsKey, propName)] = dependentProps
+            }
+
+            unless(property.setter.HasValue)
+                Message.Warning($"$macroName macro ignored on property without a setter.");
+
+            foreach(option in options) 
+            {
+                | <[ HideSelfChanges ]>           => _ = _ignoredProperties.Add(tb, property.Name);
+                | <[ Dependent = $prop ]> when options is [_] 
+                                          with props = [prop]
+                | <[ Dependent = [..$props] ]>    => SetDependentProps(tb, property.Name, props)
+                | e => Message.Error(e.Location, 
+                                     $"Invalid options syntax in $macroName macro, valid options are: 'Dependent = [Prop1, Prop2]' and 'HideSelfChanges'.")
+            }
+        }
+
+        public GetMacroName(this macroInstance : IMacro) : string
+        {
+            macroInstance.GetName().Split(':').First()
+        }
+
+        public TrySetMacroAttributeSpecified(this tb : TypeBuilder, macroInstance : IMacro, data : object = null) : bool
+        {
+            def key = (macroInstance.GetType().GUID, data);
+            tb.UserData[key] = !tb.UserData.Contains(key);
+            tb.UserData[key] :> bool
+        }
+
+        private MethodExists(this tb : TypeBuilder, methodName : Name) : bool
+        {
+            tb.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).
+               Exists(method => method.Name == methodName.Id)
+        }
+
+        private GetRaiseChangedMethodName(tb : TypeBuilder) : Name
+        {
+            assert(tb.UserData.Contains(_raiseChangedMethodKey));
+
+            tb.UserData[_raiseChangedMethodKey] :> Name
+        }
+
+        private SetRaiseChangedMethodName(tb : TypeBuilder, raiseChangedMethodName : Name) : void
+        {
+            tb.UserData[_raiseChangedMethodKey] = raiseChangedMethodName
+        }
+
+        private _ignoredProperties     = SCG.HashSet.[TypeBuilder * string]();
+        private _dependentPropsKey     = Guid.NewGuid();
+        private _raiseChangedMethodKey = Guid.NewGuid();
+        private _defaultRaiseChangedMethodName = Name("OnPropertyChanged");
+    }
+}

--- a/snippets/Nemerle.WPF/Nemerle.WPF/NotifyPropertyChanged.n
+++ b/snippets/Nemerle.WPF/Nemerle.WPF/NotifyPropertyChanged.n
@@ -87,7 +87,7 @@ namespace Nemerle.WPF
                                                     | <[ $(methodName : name) ]> => methodName
                                                     | <[()]> => _defaultRaiseChangedMethodName
                                                     | e => Message.Error(e.Location, 
-                                                                    $"Specify a valid method for property changed event raising (e.g. $macroName(OnPropertyChanged)).");
+                                                                    $"Specify a valid method for property changed event raising (e.g. [$macroName(OnPropertyChanged)]).");
                                                         _defaultRaiseChangedMethodName
                                                 };
 

--- a/snippets/Nemerle.WPF/Test/Main.n
+++ b/snippets/Nemerle.WPF/Test/Main.n
@@ -79,6 +79,12 @@ module Program
   [STAThread]
   Main() : void
   {
+    RunDependencyPropertyTest();
+    RunNotifyPropertyChangedTests();
+  }
+  
+  RunDependencyPropertyTest() : void
+  {
     def traceProperties = control => WriteLine($"Control: $(control.Columns) column(s), $(control.Rows) row(s), IsEmpty = $(control.IsEmpty)");
 
     def control = SampleGrid();
@@ -120,6 +126,11 @@ module Program
     } catch {
       // Report an exception about invalid value
       | ex is ArgumentException => WriteLine(ex.Message)
-    }
+    }  
+  }
+  
+  RunNotifyPropertyChangedTests() : void
+  {
+      PersonTests.Run()
   }
 }

--- a/snippets/Nemerle.WPF/Test/NotifyPropertyChangedTests.n
+++ b/snippets/Nemerle.WPF/Test/NotifyPropertyChangedTests.n
@@ -1,0 +1,120 @@
+﻿using Nemerle.Assertions;
+using Nemerle.Collections;
+using Nemerle.Extensions;
+using Nemerle.Utility;
+using Nemerle.Text;
+using Nemerle.WPF;
+
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+using System.Console;
+
+[NotifyPropertyChanged]
+public class Person
+{
+    public Age       : int { get { DateTime.Today.Year - BirthDate.Year } }
+
+    [NotifyChangedOptions(Dependent = [Age, FullNameAndAge], HideSelfChanges)]
+    public BirthDate : DateTime { get; set; }
+    
+    [NotifyChangedOptions(Dependent = FullNameAndAge)]
+    public FirstName : string { get; set; }
+    
+    [NotifyChangedOptions(Dependent = FullNameAndAge)]
+    public LastName  : string { get; set; }
+    
+    public FullNameAndAge  : string { get { $"$FirstName $LastName $Age"} }
+    
+    [NotifyChangedOptions(HideSelfChanges)]
+    public IgnoredProperty : string { get; set; }
+    
+    public RaiseIgnoredPropertyChanged() : void
+    {
+        RaisePropertyChanged(IgnoredProperty);
+    }
+    
+    public RaiseAllPropertiesChanged() : void
+    {
+        RaisePropertyChanged(null); //"null for the propertyName parameter indicates that all of the properties have changed" (http://msdn.microsoft.com/en-us/library/system.componentmodel.propertychangedeventargs.propertyname.aspx)
+    }
+}
+
+[NotifyPropertyChanged]
+public class Student : Person
+{
+    public Id : uint { get; set; }
+}
+
+public module PersonTests
+{
+    public Run() : void
+    {
+        def person = Person();
+        def eventData = Dictionary();
+        person.PropertyChanged += (_, e) => { if (eventData.ContainsKey(e.PropertyName)) eventData[e.PropertyName] += 1 else eventData[e.PropertyName] = 1 }
+        
+        person.BirthDate = DateTime.Now;
+        assert(eventData["Age"] == 1);
+        assert(eventData["FullNameAndAge"] == 1);
+        assert(!eventData.ContainsKey("BirthDate")); //BirthDate marked with HideSelfChanges option 
+        
+        eventData.Clear();
+        person.IgnoredProperty = "value";
+        assert(!eventData.Any());
+        
+        eventData.Clear();
+        person.RaiseIgnoredPropertyChanged();
+        assert(eventData["IgnoredProperty"] == 1);
+        
+        mutable allPropsChanged;
+        def person1 = Person();
+        person1.PropertyChanged += (_, e) => { allPropsChanged = (e.PropertyName == null) }
+        person1.RaiseAllPropertiesChanged();
+        assert(allPropsChanged);
+        
+        eventData.Clear();
+        def student = Student();
+        student.PropertyChanged += (_, e) => { if (eventData.ContainsKey(e.PropertyName)) eventData[e.PropertyName] += 1 else eventData[e.PropertyName] = 1 };
+        student.Id = 123;
+        assert(eventData["Id"] == 1);
+    }
+}
+
+//negative tests
+
+//[NotifyPropertyChanged]
+//public delegate Foo() : void; //error : Macro NotifyPropertyChanged is not valid on this declaration type. It is only valid on 'class' declarations.
+
+//[NotifyPropertyChanged] //error : Duplicates of 'NotifyPropertyChanged' macroattribute are not allowed.
+//[NotifyPropertyChanged]
+//class A {}
+
+//[NotifyPropertyChanged("Method")]//error : Specify a valid method for property changed event raising (e.g. NotifyPropertyChanged(OnPropertyChanged))
+//class A1 {}
+
+//[NotifyPropertyChanged]
+//public class A2
+//{
+//    [NotifyChangedOptions(HideSelfChanges)] //warning : NotifyChangedOptions macro ignored on property without a setter.
+//    public Prop       : int { get; }
+
+//    [NotifyChangedOptions(Dependent = [Prop3, Prop], HideSelfChanges)] //error : Class 'A2' does not contain a property with the name 'Prop3'.
+//    public Prop2 : DateTime { get; set; }
+    
+//    [NotifyChangedOptions(Dependent = ["Prop3 + 7"], HideSelfChanges)] //error : Expected simple name.
+//    public Prop4 : DateTime { get; set; }
+    
+//    public CustomNotify() : void
+//    {
+//        RaisePropertyChanged("test"+7); //error : Specify a property for changed event raising (e.g. RaisePropertyChanged(PropName)).
+//        RaisePropertyChanged(Prop5); //error : Class 'A2' does not contain a property with the name 'Prop5'.
+//        RaisePropertyChanged(Prop, Raise); //error : Specify a valid method for property changed event raising (e.g. RaisePropertyChanged(PropName, OnPropertyChanged)).
+//    }
+//}

--- a/snippets/Nemerle.WPF/Test/NotifyPropertyChangedTests.n
+++ b/snippets/Nemerle.WPF/Test/NotifyPropertyChangedTests.n
@@ -86,35 +86,3 @@ public module PersonTests
         assert(eventData["Id"] == 1);
     }
 }
-
-//negative tests
-
-//[NotifyPropertyChanged]
-//public delegate Foo() : void; //error : Macro NotifyPropertyChanged is not valid on this declaration type. It is only valid on 'class' declarations.
-
-//[NotifyPropertyChanged] //error : Duplicates of 'NotifyPropertyChanged' macroattribute are not allowed.
-//[NotifyPropertyChanged]
-//class A {}
-
-//[NotifyPropertyChanged("Method")]//error : Specify a valid method for property changed event raising (e.g. NotifyPropertyChanged(OnPropertyChanged))
-//class A1 {}
-
-//[NotifyPropertyChanged]
-//public class A2
-//{
-//    [NotifyChangedOptions(HideSelfChanges)] //warning : NotifyChangedOptions macro ignored on property without a setter.
-//    public Prop       : int { get; }
-
-//    [NotifyChangedOptions(Dependent = [Prop3, Prop], HideSelfChanges)] //error : Class 'A2' does not contain a property with the name 'Prop3'.
-//    public Prop2 : DateTime { get; set; }
-    
-//    [NotifyChangedOptions(Dependent = ["Prop3 + 7"], HideSelfChanges)] //error : Expected simple name.
-//    public Prop4 : DateTime { get; set; }
-    
-//    public CustomNotify() : void
-//    {
-//        RaisePropertyChanged("test"+7); //error : Specify a property for changed event raising (e.g. RaisePropertyChanged(PropName)).
-//        RaisePropertyChanged(Prop5); //error : Class 'A2' does not contain a property with the name 'Prop5'.
-//        RaisePropertyChanged(Prop, Raise); //error : Specify a valid method for property changed event raising (e.g. RaisePropertyChanged(PropName, OnPropertyChanged)).
-//    }
-//}

--- a/snippets/Nemerle.WPF/Test/NotifyPropertyChangedTests.n
+++ b/snippets/Nemerle.WPF/Test/NotifyPropertyChangedTests.n
@@ -1,0 +1,88 @@
+﻿using Nemerle.Assertions;
+using Nemerle.Collections;
+using Nemerle.Extensions;
+using Nemerle.Utility;
+using Nemerle.Text;
+using Nemerle.WPF;
+
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+using System.Console;
+
+[NotifyPropertyChanged]
+public class Person
+{
+    public Age       : int { get { DateTime.Today.Year - BirthDate.Year } }
+
+    [NotifyChangedOptions(Dependent = [Age, FullNameAndAge], HideSelfChanges)]
+    public BirthDate : DateTime { get; set; }
+    
+    [NotifyChangedOptions(Dependent = FullNameAndAge)]
+    public FirstName : string { get; set; }
+    
+    [NotifyChangedOptions(Dependent = FullNameAndAge)]
+    public LastName  : string { get; set; }
+    
+    public FullNameAndAge  : string { get { $"$FirstName $LastName $Age"} }
+    
+    [NotifyChangedOptions(HideSelfChanges)]
+    public IgnoredProperty : string { get; set; }
+    
+    public RaiseIgnoredPropertyChanged() : void
+    {
+        RaisePropertyChanged(IgnoredProperty);
+    }
+    
+    public RaiseAllPropertiesChanged() : void
+    {
+        RaisePropertyChanged(null); //"null for the propertyName parameter indicates that all of the properties have changed" (http://msdn.microsoft.com/en-us/library/system.componentmodel.propertychangedeventargs.propertyname.aspx)
+    }
+}
+
+[NotifyPropertyChanged]
+public class Student : Person
+{
+    public Id : uint { get; set; }
+}
+
+public module PersonTests
+{
+    public Run() : void
+    {
+        def person = Person();
+        def eventData = Dictionary();
+        person.PropertyChanged += (_, e) => { if (eventData.ContainsKey(e.PropertyName)) eventData[e.PropertyName] += 1 else eventData[e.PropertyName] = 1 }
+        
+        person.BirthDate = DateTime.Now;
+        assert(eventData["Age"] == 1);
+        assert(eventData["FullNameAndAge"] == 1);
+        assert(!eventData.ContainsKey("BirthDate")); //BirthDate marked with HideSelfChanges option 
+        
+        eventData.Clear();
+        person.IgnoredProperty = "value";
+        assert(!eventData.Any());
+        
+        eventData.Clear();
+        person.RaiseIgnoredPropertyChanged();
+        assert(eventData["IgnoredProperty"] == 1);
+        
+        mutable allPropsChanged;
+        def person1 = Person();
+        person1.PropertyChanged += (_, e) => { allPropsChanged = (e.PropertyName == null) }
+        person1.RaiseAllPropertiesChanged();
+        assert(allPropsChanged);
+        
+        eventData.Clear();
+        def student = Student();
+        student.PropertyChanged += (_, e) => { if (eventData.ContainsKey(e.PropertyName)) eventData[e.PropertyName] += 1 else eventData[e.PropertyName] = 1 };
+        student.Id = 123;
+        assert(eventData["Id"] == 1);
+    }
+}

--- a/snippets/Nemerle.WPF/Test/Test.nproj
+++ b/snippets/Nemerle.WPF/Test/Test.nproj
@@ -54,6 +54,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Main.n" />
+    <Compile Include="NotifyPropertyChangedTests.n" />
     <Compile Include="Properties\AssemblyInfo.n" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The implementation is based on this post http://v2matveev.blogspot.ru/2010/08/inotifypropertychanged-strikes-back.html.
More use cases and better diagnostic messages added.
