### PR TITLE
Discard DebugInfo on left side of Assign in object initalizer conversion to linq expression.

### DIFF
--- a/Linq/Macro/ToExpressionImpl.n
+++ b/Linq/Macro/ToExpressionImpl.n
@@ -147,6 +147,9 @@ namespace Nemerle.Linq
               addBinding(e1);
               addBinding(e2);
               
+            | Assign(DebugInfo(expr, _), source) =>
+              addBinding(TExpr.Assign(expr, source))
+              
             | Assign(FieldMember(obj, field), source) =>
               def sourceTree = ToExpr(lparms, source);
               def fieldRef = PExpr.Typed(TExpr.FieldOf(obj.Type, field));                    

--- a/Linq/Tests/Tests.n
+++ b/Linq/Tests/Tests.n
@@ -20,6 +20,7 @@ namespace Tests
   class Data
   {
     public Id : Guid { get; set; }
+    public Name : string { get; set; }
   }
 
   [TestFixture]
@@ -207,6 +208,16 @@ namespace Tests
     {
       def f = ToExpression(fun () { System.Environment.NewLine });
       Assert.AreEqual(System.Environment.NewLine, f.Compile()());
+    }
+
+    [Test]
+    public ObjectInitializer() : void
+    {
+      def f = ToExpression((x, y) => Data() <- { Id = x; Name = y }).Compile();
+      def id = Guid.NewGuid();
+      def data = f(id, "N");
+      Assert.AreEqual(id, data.Id);
+      Assert.AreEqual("N", data.Name);
     }
     
     [Test]


### PR DESCRIPTION
Fixes #588
