### PR TITLE
Use opcode unbox.any when casting from object to value type

### DIFF
--- a/ncc/generation/ILEmitter.n
+++ b/ncc/generation/ILEmitter.n
@@ -914,6 +914,9 @@ namespace Nemerle.Compiler
             /* perform conversion of value types */
             emit_value_type_conversion (expr.Location, val.FixedType(), cast_to_type.Fix (), is_checked)
           }
+          else if (SystemTypeCache.Object : object == type_of_expr && cast_to_stype.IsValueType) {
+          	_ilg.Emit (OpCodes.Unbox_Any, cast_to_stype)
+          }
           else if (is_generic || 
                    SystemTypeCache.Object : object == type_of_expr || 
                    type_of_expr.IsInterface || 


### PR DESCRIPTION
I was trying to get Nemerle working with Unity's IL2CPP, and it wouldn't compile the Nemerle.dll properly.  It turns out that the `unbox` IL opcode is not supported by their compiler (or JSIL) because it's an uncommon opcode that's never generated by C# (and maybe it's difficult to implement?).  Nemerle usually uses it to cast from an `object` to a value type, with `unbox` followed by `ldobj`.  

There is another opcode, `unbox.any` that is more appropriate in this case.  When a value type is boxed, `unbox.any` is equivalent to `unbox` followed by `ldobj`.  [See here for more info](https://msdn.microsoft.com/en-us/library/system.reflection.emit.opcodes.unbox_any)

I simply created a new clause in the ILEmitter to emit `unbox.any` when casting from an `object` to a value type.  With this pull request, DLL's built with Nemerle for .NET 3.5 should mostly work with IL2CPP.
