### PR TITLE
Ryu jit performance fix

### DIFF
--- a/ncc/typing/TypeVar.n
+++ b/ncc/typing/TypeVar.n
@@ -1498,12 +1498,7 @@ namespace Nemerle.Compiler
     // assumes normalized array!
     ContainedIn (s : array [TypeVar], max : int) : bool
     {
-      def loop (i) {
-        if (i >= max) false
-        else if (s [i] : object == this : object) true
-        else loop (i + 1)
-      }
-      loop (0)
+      Array.IndexOf(s, this, 0, max) >= 0;
     }
 
 
@@ -1519,19 +1514,17 @@ namespace Nemerle.Compiler
         def res = array (size + 1);
         mutable res_ptr = 0;
 
-        if (size > 42)
+        if (size > 20)
         {
-          def ht = System.Collections.Hashtable ();
+          def hs = System.Collections.Generic.HashSet ();
           foreach (tv in s1) {
-            when (tv != null && !ht.Contains (tv.id)) {
-              ht [tv.id] = ht;
+            when (tv != null && hs.Add (tv.id)) {
               res [res_ptr] = tv;
               ++res_ptr
             }
           }
           foreach (tv in s2) {
-            when (tv != null && !ht.Contains (tv.id)) {
-              ht [tv.id] = ht;
+            when (tv != null && hs.Add (tv.id)) {
               res [res_ptr] = tv;
               ++res_ptr
             }
@@ -1565,15 +1558,14 @@ namespace Nemerle.Compiler
       def res = array (if (size1 < size2) size1 else size2);
       mutable res_ptr = 0;
 
-      if (size1 + size2 > 42) {
-        def ht = System.Collections.Hashtable ();
+      if (size1 + size2 > 20) {
+        def hs = System.Collections.Generic.HashSet();
         foreach (tv in s1) {
           when (tv != null)
-            ht [tv.id] = ht;
+            _ = hs.Add(tv.id);
         }
         foreach (tv in s2) {
-          when (tv != null && ht.Contains (tv.id)) {
-            ht.Remove (tv.id);
+          when (tv != null && hs.Contains(tv.id)) {
             res [res_ptr] = tv;
             ++res_ptr
           }


### PR DESCRIPTION
Our code on .Net 4.6 compiles to 60 times slower than on .Net 4.5 with the same version of the compiler and hardware.

Win7 / .Net 4.5

```
 ------------- STATS ---------------
AllTypeBuilders: 3913 
FirstClassFunctions: 0 
FunctionClosures: 62 
RealRunningTime: 36832ms
------------- END STATS ---------------
```

Win10 /  .Net 4.6

```
    ------------- STATS ---------------
      AllTypeBuilders:     3913
      FirstClassFunctions: 0
      FunctionClosures:    62
      RealRunningTime:     2205750ms
    ------------- END STATS ---------------
```

![perf_profile](https://cloud.githubusercontent.com/assets/1642954/10244576/ed0554ba-6908-11e5-83bb-9f91d4b03847.png)

Сhanging this part of the compiler fixed the problem.

Win7 / .Net 4.5

```
------------- STATS ---------------
  AllTypeBuilders:     3913
  FirstClassFunctions: 0
  FunctionClosures:    62
  RealRunningTime:     28189ms
------------- END STATS --------------
```

Win10 / .Net 4.6

```
 ------------- STATS ---------------
   AllTypeBuilders:     3913
   FirstClassFunctions: 0
   FunctionClosures:    62
   RealRunningTime:     37344ms
 ------------- END STATS ---------------
```
