### PR TITLE
Fix ncc in mono

### DIFF
--- a/ncc/generation/ILEmitter.n
+++ b/ncc/generation/ILEmitter.n
@@ -287,14 +287,20 @@ namespace Nemerle.Compiler
     }
     #endregion
 
+	static IsRuntimeType (t : System.Type) : bool
+	{
+		def typeOfType = t.GetType();
+		typeOfType.Equals (MS_NET_RUNTIME_TYPE) || typeOfType.Equals (MONO_RUNTIME_TYPE)
+	}
+	
     static FrameworkGetConstructor (t : System.Type, mutable m : ConstructorInfo) : ConstructorInfo
     {
       if (RUNTIME_TYPE != null)
-        if(t.GetType().Equals (RUNTIME_TYPE))
+        if(IsRuntimeType (t))
           GetHackishConstructor (t, m)
         else {
           def td = t.GetGenericTypeDefinition ();
-          when (td.GetType().Equals (RUNTIME_TYPE))
+          when (IsRuntimeType (td))
             m = GetHackishConstructor (td, m);
 
           TypeBuilder.GetConstructor (t, m)
@@ -307,11 +313,11 @@ namespace Nemerle.Compiler
     {
       // workaround MS.NET and Mono limitation of not allowing RuntimeType in TypeBuilder.GetMethod
       if (RUNTIME_TYPE != null)
-        if (t.GetType().Equals (RUNTIME_TYPE))
+        if (IsRuntimeType (t))
           GetHackishMethod (t, m)
         else {
           def td = t.GetGenericTypeDefinition ();
-          when (td.GetType().Equals (RUNTIME_TYPE))
+          when (IsRuntimeType (td))
             m = GetHackishMethod (td, m);
 
           TypeBuilder.GetMethod (t, m)
@@ -322,13 +328,12 @@ namespace Nemerle.Compiler
 
     static FrameworkGetField (t : System.Type, mutable m : FieldInfo) : FieldInfo
     {
-      // use hack only on .NET
       if (MS_NET_RUNTIME_TYPE != null)
-        if(t.GetType().Equals (MS_NET_RUNTIME_TYPE))
+        if(IsRuntimeType (t))
           GetHackishField (t, m);
         else {
           def td = t.GetGenericTypeDefinition ();
-          when (td.GetType().Equals (MS_NET_RUNTIME_TYPE))
+          when (IsRuntimeType (td))
             m = GetHackishField (td, m);
 
           TypeBuilder.GetField (t, m)


### PR DESCRIPTION
Ncc doesn't work in mono now.
Error:
 ArgumentException (type is not TypeBuilder but System.MonoType Parameter name: type)
at System.Reflection.Emit.TypeBuilder.GetMethod (System.Type type, System.Reflection.MethodInfo method) in <filename unknown>:line 0
at Nemerle.Compiler.ILEmitter.FrameworkGetMethod (System.Type t, System.Reflection.MethodInfo m) in <filename unknown>:line 0
...

This PR fix it.
Look hacky, as it was.
