### PR TITLE
Set NeedAddress for TExpr.DebugInfo in TExpr.setNeedAddress()

### DIFF
--- a/ncc/typing/TypedTree.n
+++ b/ncc/typing/TypedTree.n
@@ -1072,7 +1072,13 @@ namespace Nemerle.Compiler.Typedtree
 
       match (this)
       {
-        | TExpr.DebugInfo(expr=expr) => expr.setNeedAddress(from_ctor)
+        | TExpr.DebugInfo(expr=expr) =>
+          if (expr.setNeedAddress(from_ctor)) {
+            flags |= TExprFlags.NeedAddress;
+            true
+          } else {
+            false
+          }
         | StaticRef
         | LocalRef
         | ArrayIndexer


### PR DESCRIPTION
When TExpr.setNeedAddress() is called for a TExpr.DebugInfo, it will try to
call setNeedAddress() for the inner expression, but will not set it for
the expression itself.

This breaks ILEmitter.emit_and_convert_to_address() which then will assume
that the emit(expr) will push the object, not the address, onto the stack.

Setting the NeedAddress flag for the expression itself fixes this.

A test case (must be compiled with -g):

```
public struct EnumerableValueType : System.Collections.Generic.IEnumerable[int] {
  public GetEnumerator () : System.Collections.Generic.IEnumerator[int] {
    [].GetEnumerator ()
  }
}
public class C {
  public static GetValue () : EnumerableValueType {
    EnumerableValueType ()
  }
  public static Main () : void {
    def value = GetValue();
    foreach (_ in value) {}
  }
}
```

Without this fix the resulting code will contain:

```
.locals init (
    valuetype EnumerableValueType   V_0,
    valuetype EnumerableValueType   V_1,
    class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>V_2)
[...]
IL_0008:  nop 
IL_0009:  nop 
IL_000a:  ldloca.s 0
IL_000c:  stloc.1 
IL_000d:  ldloca.s 1
IL_000f:  call instance class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> valuetype EnumerableValueType::GetEnumerator()
```

Which is broken: IL_000a gets an address and tries to store it in a local with type EnumerableValueType.
The code will output:

```
[ERROR] FATAL UNHANDLED EXCEPTION: System.InvalidProgramException: Invalid IL code in C:Main (): IL_000c: stloc.1   
```

With the fix, the code will be correct:

```
.locals init (
    valuetype EnumerableValueType   V_0,
    class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>V_1)
[...]
IL_0008:  nop 
IL_0009:  nop 
IL_000a:  ldloca.s 0
IL_000c:  call instance class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> valuetype EnumerableValueType::GetEnumerator()
```
