### PR TITLE
Remove GC.Collect() from Nemerle.Completion2.Engine.BuildTypesTreeImpl to prevent VS UI freezing

### DIFF
--- a/snippets/VS2010/Nemerle.Compiler.Utils/Nemerle.Completion2/Engine/BackgroundWorks/Engine-BuildTypeTree.n
+++ b/snippets/VS2010/Nemerle.Compiler.Utils/Nemerle.Completion2/Engine/BackgroundWorks/Engine-BuildTypeTree.n
@@ -266,7 +266,10 @@ namespace Nemerle.Completion2
           {
             def ext = System.IO.Path.GetExtension(sourceFileName);
             when (string.Compare(ext, ".n", StringComparison.OrdinalIgnoreCase) != 0 && Parser.IsExtensionRegistered(ext))
+			{
+			  UnsubscribeSourceChanged(fileIndex, OnSourceChanged);
               SubscribeSourceChanged(fileIndex, OnSourceChanged, invokeAfterSubscription = false);
+			}
           }
 
           when (request.Stop)
@@ -359,7 +362,7 @@ namespace Nemerle.Completion2
           when (IsProjectAvailable)
             ignore(ProjectAvailableEvent.Set());
 
-        GC.Collect();
+        //GC.Collect();
 
         request.MarkAsCompleted();
         


### PR DESCRIPTION
Editing code in large solutions like Nitra causes Visual Studio freezes while Nemerle language service is doing parsing and type checking. Each such check calls `GC.Collect()` for some unclear reason, which causes short (1-3 seconds) UI freezes all the time. This PR removes that `GC.Collect()` call. As far as I can see, the freezes has gone, devenv.exe working set stays at about 1.5GB, which is totally ok. 

(also this PR adds `UnsubscribeSourceChanged` call to prevent (possible) memory leaks)
