### PR TITLE
nemerle.el: Provide feature

### DIFF
--- a/misc/nemerle.el
+++ b/misc/nemerle.el
@@ -883,4 +883,5 @@ Mode map
   
   (run-hooks 'nemerle-mode-hook))
 
+(provide 'nemerle)
 ;;; nemerle.el ends here


### PR DESCRIPTION
This allows loading this library the way Emacs libraries are normally loaded.
